### PR TITLE
Make ESP32 release builds work

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
     "rust-analyzer.cargo.features": [
         "esp32"
     ],
+    "rust-analyzer.cargo.target": "xtensa-esp32-none-elf",
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d862f14e042f75b95236d4ef1bb3d5c170964082d1e1e9c3ce689a2cbee217c"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +206,7 @@ dependencies = [
 name = "esp-wifi"
 version = "0.1.0"
 dependencies = [
+ "atomic-polyfill",
  "critical-section",
  "embedded-hal",
  "esp32-hal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ xtensa-lx-rt = { version = "0.11.0", optional = true }
 xtensa-lx = { version = "0.6.0", optional = true }
 smoltcp = { version = "0.8.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "0.2.6"
+atomic-polyfill = "0.1.7"
 
 [build-dependencies]
 riscv-target = { version = "0.1.2", optional = true }

--- a/examples/dhcp_esp32c3/main.rs
+++ b/examples/dhcp_esp32c3/main.rs
@@ -60,9 +60,9 @@ fn main() -> ! {
     let res = wifi_start();
     println!("\n\n\nwifi_start returned {}", res);
 
-    // println!("Call wifi_start_scan");
-    // let res = wifi::wifi_start_scan();
-    // println!("wifi_start_scan returned {}", res);
+    println!("Call wifi_start_scan");
+    let res = wifi::wifi_start_scan();
+    println!("wifi_start_scan returned {}", res);
     print_scan_result();
     println!("\n\n\n\n");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(c_variadic)]
+#![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 
 pub mod binary;
 pub mod compat;
@@ -11,6 +12,8 @@ pub mod timer;
 pub mod wifi;
 
 pub mod tasks;
+
+pub(crate) mod memory_fence;
 
 extern "C" {
     // ROM functions, see esp32c3-link.x

--- a/src/memory_fence.rs
+++ b/src/memory_fence.rs
@@ -1,0 +1,11 @@
+#[cfg(target_arch = "xtensa")]
+pub(crate) fn memory_fence() {
+    unsafe {
+        core::arch::asm!("memw");
+    }
+}
+
+#[cfg(target_arch = "riscv32")]
+pub(crate) fn memory_fence() {
+    // no-op
+}

--- a/src/preempt/preempt_riscv.rs
+++ b/src/preempt/preempt_riscv.rs
@@ -61,10 +61,14 @@ pub fn task_create(task: extern "C" fn()) -> usize {
         let i = TASK_TOP;
         TASK_TOP += 1;
         CTX_TASKS[i].pc = task as usize;
-        CTX_TASKS[i].trap_frame.sp = &TASK_STACK as *const _ as usize
+
+        // stack must be aligned by 16
+        let task_stack_ptr = &TASK_STACK as *const _ as usize
             + (STACK_SIZE as usize * i as usize)
             + STACK_SIZE as usize
             - 4;
+        let stack_ptr = task_stack_ptr - (task_stack_ptr % 0x10);
+        CTX_TASKS[i].trap_frame.sp = stack_ptr;
 
         CTX_NOW = i;
         i

--- a/src/preempt/preempt_xtensa.rs
+++ b/src/preempt/preempt_xtensa.rs
@@ -1,3 +1,4 @@
+use atomic_polyfill::*;
 use xtensa_lx_rt::exception::Context;
 
 #[derive(Debug, Clone, Copy)]
@@ -10,7 +11,7 @@ const MAX_TASK: usize = 3;
 
 pub static mut TASK_STACK: [u8; STACK_SIZE * MAX_TASK] = [0x0u8; STACK_SIZE * MAX_TASK];
 
-pub static mut FIRST_SWITCH: bool = true;
+pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
 
 pub static mut TASK_TOP: usize = 0;
 
@@ -230,8 +231,8 @@ pub fn next_task() {
 
 pub fn task_switch(trap_frame: &mut Context) {
     unsafe {
-        if FIRST_SWITCH {
-            FIRST_SWITCH = false;
+        if FIRST_SWITCH.load(Ordering::Relaxed) {
+            FIRST_SWITCH.store(false, Ordering::Relaxed);
             TASK_TOP += 1;
             CTX_NOW = TASK_TOP - 1;
         }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -6,6 +6,7 @@ use crate::timer::get_systimer_count;
 use crate::wifi::send_data_if_needed;
 use crate::{
     compat::{self, timer_compat::TIMERS},
+    memory_fence::memory_fence,
     trace,
 };
 
@@ -32,6 +33,7 @@ pub extern "C" fn worker_task2() {
 
         critical_section::with(|_| unsafe {
             for i in 0..TIMERS.len() {
+                memory_fence();
                 TIMERS[i] = match &TIMERS[i] {
                     Some(old) => {
                         if old.active && get_systimer_count() >= old.expire {


### PR DESCRIPTION
This addresses #6 

There are some things still odd here - those need further investigation but I think it's out of scope for this PR
- for ESP32 the `TICKS_PER_SECOND` value doesn't make sense but this value makes things work
- sometimes the release build for ESP32C3 isn't working when flashed - interestingly it helps to clean and rebuild
- probably I added a bit too many `memory_fence()` calls - shouldn't really hurt however

@jessebraham if you don't mind could you verify it's now working for you for both chips in both release and dev mode?
