### PR TITLE
At least some wifi logs on ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://github.com/espressif/esp-wireless-drivers-3rdparty/archive/45701c0.zip
 
 This is even more experimental than support for ESP32C3.
 
-- There are no wifi-logs so you have to be a bit more patient when trying it out since there is no indication of progress. 
+- The WiFi logs only print the format string - not the actual values. 
 - Also there might be some packet loss and a bit worse performance than on ESP32C3 currently. 
 - The code runs on a single core and is currently not multi-core safe!
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,8 +1,8 @@
 use crate::compat::queue::SimpleQueue;
 use crate::compat::timer_compat::Timer;
-use crate::debug;
 use crate::preempt::preempt::task_create;
 use crate::timer::get_systimer_count;
+use crate::verbose;
 use crate::wifi::send_data_if_needed;
 use crate::{
     compat::{self, timer_compat::TIMERS},
@@ -37,7 +37,7 @@ pub extern "C" fn worker_task2() {
                 TIMERS[i] = match &TIMERS[i] {
                     Some(old) => {
                         if old.active && get_systimer_count() >= old.expire {
-                            debug!("timer is due.... {:p}", old.ptimer);
+                            verbose!("timer is due.... {:p}", old.ptimer);
                             let fnctn: fn(*mut crate::binary::c_types::c_void) =
                                 core::mem::transmute(old.timer_ptr);
                             to_run.enqueue((fnctn, old.arg_ptr));

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -40,7 +40,6 @@ use crate::{
     debug, print, println, verbose,
 };
 
-#[cfg(feature = "esp32c3")]
 use crate::binary::include::{
     esp_wifi_internal_set_log_level, esp_wifi_internal_set_log_mod, u_int32_t, wifi_log_level_t,
     wifi_log_module_t_WIFI_LOG_MODULE_ALL, WIFI_LOG_SUBMODULE_ALL,
@@ -78,8 +77,6 @@ pub fn init_clocks() {
 }
 
 pub fn wifi_set_log_verbose() {
-    // really bad things happen on ESP32!
-    #[cfg(feature = "esp32c3")]
     unsafe {
         let g_wifi_log_submodule: u_int32_t = WIFI_LOG_SUBMODULE_ALL;
         let level: wifi_log_level_t = crate::binary::include::wifi_log_level_t_WIFI_LOG_VERBOSE;

--- a/src/wifi/os_adapter.rs
+++ b/src/wifi/os_adapter.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         work_queue::queue_work,
     },
-    debug, trace,
+    trace,
     wifi::RANDOM_GENERATOR,
 };
 
@@ -1662,9 +1662,6 @@ pub unsafe extern "C" fn log_write(
     format: *const crate::binary::c_types::c_char,
     _args: ...
 ) {
-    let s = StrBuf::from(format);
-    debug!("LOG: {}", s.as_str_ref());
-
     #[cfg(feature = "esp32c3")]
     syslog(_level, format, _args);
 }
@@ -1691,10 +1688,12 @@ pub unsafe extern "C" fn log_writev(
     format: *const crate::binary::c_types::c_char,
     _args: va_list,
 ) {
-    let s = StrBuf::from(format);
-    debug!("LOGV: {}", s.as_str_ref());
+    #[cfg(feature = "esp32")]
+    {
+        let s = StrBuf::from(format);
+        crate::println!("{}", s.as_str_ref());
+    }
 
-    // TODO va_list on xtensa?
     #[cfg(feature = "esp32c3")]
     {
         let _args = core::mem::transmute(_args);


### PR DESCRIPTION
Again, not much to review. Just want to make sure it doesn't break anything for anyone.

This enables WiFi logs for ESP32. It just logs the format string of the log message since there is a problem with the va_list - but that is much better than having nothing logged

This partially resolves #16 