### PR TITLE
Provide implementation of embedded-svc wifi trait

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -20,4 +20,4 @@ rustflags = [
 target = "riscv32i-unknown-none-elf"
  
 [unstable]
-build-std = [ "core" ]
+build-std = [ "core", "alloc" ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
-    "editor.formatOnSave": true,
+    // "editor.formatOnSave": true,
     "rust-analyzer.cargo.features": [
-        "esp32"
+        "esp32",
+        "allocator",
+        "embedded-svc",
     ],
     "rust-analyzer.cargo.target": "xtensa-esp32-none-elf",
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d862f14e042f75b95236d4ef1bb3d5c170964082d1e1e9c3ce689a2cbee217c"
+checksum = "e14bf7b4f565e5e717d7a7a65b2a05c0b8c96e4db636d6f780f03b15108cdd1b"
 dependencies = [
  "critical-section",
 ]
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1e89b93912c97878305b70ef6b011bfc74622e7b79a9d4a0676c7663496bcd"
+checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
 dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
@@ -154,8 +154,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
 ]
 
 [[package]]
@@ -166,10 +176,23 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "strsim",
- "syn 1.0.90",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -178,9 +201,20 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
- "darling_core",
- "quote 1.0.17",
- "syn 1.0.90",
+ "darling_core 0.10.2",
+ "quote 1.0.18",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -205,6 +239,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-svc"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a3de276c11e6a11fe2782b597ac31978e2c4f07301e76aa6e46eafe1ec81b7"
+dependencies = [
+ "anyhow",
+ "enumset",
+ "log",
+ "no-std-net",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "embedded-time"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,9 +268,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4799cdb24d48f1f8a7a98d06b7fde65a85a2d1e42b25a889f5406aa1fbefe074"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea83a3fbdc1d999ccfbcbee717eab36f8edf2d71693a23ce0d7cca19e085304c"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -249,11 +318,11 @@ name = "esp-hal-procmacros"
 version = "0.1.0"
 source = "git+https://github.com/esp-rs/esp-hal?rev=033824391dddb2b7e9e201d14d2e587b84dd628d#033824391dddb2b7e9e201d14d2e587b84dd628d"
 dependencies = [
- "darling",
+ "darling 0.10.2",
  "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -264,7 +333,9 @@ dependencies = [
  "critical-section",
  "embedded-hal",
  "embedded-nal",
+ "embedded-svc",
  "embedded-time",
+ "enumset",
  "esp32-hal",
  "esp32c3-hal",
  "log",
@@ -397,6 +468,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -553,9 +630,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "version_check",
 ]
 
@@ -565,8 +642,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "version_check",
 ]
 
@@ -581,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -599,11 +676,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
 ]
 
 [[package]]
@@ -725,6 +802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +833,31 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "shared-bus"
@@ -790,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 dependencies = [
  "lock_api",
 ]
@@ -822,10 +930,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
  "heck",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "rustversion",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -841,12 +949,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "unicode-xid 0.2.2",
 ]
 
@@ -926,7 +1034,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a8200930e2dbd515c231f7a46033bd6dfe1497a8e9a539878f0de8f0cd730b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ log = "0.4.16"
 smoltcp-nal = { version = "0.2.1", optional = true, features = ["shared-stack"] }
 embedded-time = { version = "0.12.1", optional = true }
 embedded-nal = { version = "0.6.0", optional = true }
+embedded-svc = { version = "0.20.3", default-features = false, features = [ "alloc" ], optional = true }
+enumset = { version = "1", default-features = false, optional = true }
 
 [build-dependencies]
 riscv-target = { version = "0.1.2", optional = true }
@@ -32,3 +34,6 @@ esp32 = [ "esp32-hal", "xtensa-lx-rt", "xtensa-lx", "critical-section/custom-imp
 wifi_logs = []
 dump_packets = []
 utils = [ "smoltcp-nal", "embedded-time", "embedded-nal" ]
+allocator = []
+enumset = []
+embedded-svc = [ "allocator", "dep:enumset", "dep:embedded-svc", "utils" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This is experimental and work-in-progress! You are welcome to contribute but probably shouldn't use this for something real yet.
+This is experimental and work-in-progress! You are welcome to experiment with it and contribute but probably shouldn't use this for something real yet.
 
 This uses the WiFi driver found in https://github.com/espressif/esp-wireless-drivers-3rdparty
 
@@ -22,14 +22,17 @@ https://github.com/espressif/esp-wireless-drivers-3rdparty/archive/45701c0.zip
 
 |Command|Chip|
 |---|---|
-|`cargo "+nightly" run --example dhcp_esp32c3 --release --target riscv32i-unknown-none-elf --features esp32c3`|ESP32C3|
-|`cargo "+esp" run --example dhcp_esp32 --release --target xtensa-esp32-none-elf --features esp32`|ESP32|
+|`cargo "+nightly" run --example dhcp_esp32c3 --release --target riscv32i-unknown-none-elf --features "esp32c3,embedded-svc"`|ESP32C3|
+|`cargo "+esp" run --example dhcp_esp32 --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc"`|ESP32|
 
 Additional you can specify these features
 |Feature|Meaning|
 |---|---|
 |wifi_logs|logs the WiFi logs from the driver at log level info|
 |dump_packets|dumps some packet info at log level info|
+|utils|Provide utilities to use `embedded-nal`, this is a default feature|
+|allocator|Provides a global allocator which just uses the internal `malloc` - it doesn't honor special alignments|
+|embedded-svc|Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` and `allocator` feature|
 
 In general you should use the release profile since otherwise the performance is quite bad.
 

--- a/examples/dhcp_esp32/main.rs
+++ b/examples/dhcp_esp32/main.rs
@@ -1,18 +1,21 @@
 #![no_std]
 #![no_main]
 
+use embedded_svc::wifi::{
+    ClientConfiguration, ClientConnectionStatus, ClientIpStatus, ClientStatus, Configuration,
+    Status, Wifi,
+};
 use esp32_hal::{pac::Peripherals, RtcCntl};
+use esp_wifi::println;
 use esp_wifi::wifi::initialize;
 use esp_wifi::wifi::utils::create_network_stack;
-use esp_wifi::{
-    binary, compat, println,
-    wifi::{self, wifi_connect},
-};
 use esp_wifi::{create_network_stack_storage, network_stack_storage, Uart};
 use xtensa_lx_rt::entry;
 
 use embedded_nal::SocketAddrV4;
 use embedded_nal::TcpClientStack;
+
+extern crate alloc;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
@@ -26,28 +29,44 @@ fn main() -> ! {
     // Disable MWDT and RWDT (Watchdog) flash boot protection
     rtc_cntl.set_wdt_global_enable(false);
 
+    let mut storage = create_network_stack_storage!(3, 8, 1);
+    let network_stack = create_network_stack(network_stack_storage!(storage));
+
+    let mut wifi_interface = esp_wifi::wifi_interface::Wifi::new(network_stack);
+
     init_logger();
 
     initialize(peripherals.TIMG1, peripherals.RNG).unwrap();
 
-    println!("Call wifi_start_scan");
-    let res = wifi::wifi_start_scan();
-    println!("wifi_start_scan returned {}", res);
-    print_scan_result();
-    println!("\n\n\n\n");
+    println!("{:?}", wifi_interface.get_status());
 
-    let mut storage = create_network_stack_storage!(3, 8, 1);
-    let mut network_stack = create_network_stack(network_stack_storage!(storage));
+    println!("Start Wifi Scan");
+    let res = wifi_interface.scan();
+    if let Ok(res) = res {
+        for ap in res {
+            println!("{:?}", ap);
+        }
+    }
 
     println!("Call wifi_connect");
-    let res = wifi_connect(SSID, PASSWORD);
-    println!("wifi_connect returned {}", res);
+    let client_config = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASSWORD.into(),
+        ..Default::default()
+    });
+    let res = wifi_interface.set_configuration(&client_config);
+    println!("wifi_connect returned {:?}", res);
 
+    println!("{:?}", wifi_interface.get_capabilities());
+    println!("{:?}", wifi_interface.get_status());
+
+    // wait to get connected
     loop {
-        if wifi::is_connected() {
+        if let Status(ClientStatus::Started(_), _) = wifi_interface.get_status() {
             break;
         }
     }
+    println!("{:?}", wifi_interface.get_status());
 
     println!("Start busy loop on main");
 
@@ -56,121 +75,76 @@ fn main() -> ! {
     let mut idx = 0;
     let mut buffer = [0u8; 8000];
     let mut waiter = 50000;
+
     loop {
-        network_stack.poll().ok();
+        wifi_interface.network_stack().poll().ok();
 
-        if let Some(ipv4_addr) = network_stack.interface().ipv4_addr() {
-            if !ipv4_addr.is_unspecified() {
-                match stage {
-                    0 => {
-                        println!("My IP is {}", ipv4_addr);
-                        println!("Lets connect");
-                        let mut sock = network_stack.socket().unwrap();
-                        let addr =
-                            SocketAddrV4::new(embedded_nal::Ipv4Addr::new(142, 250, 185, 115), 80);
-                        network_stack.connect(&mut sock, addr.into()).unwrap();
+        if let Status(
+            ClientStatus::Started(ClientConnectionStatus::Connected(ClientIpStatus::Done(config))),
+            _,
+        ) = wifi_interface.get_status()
+        {
+            match stage {
+                0 => {
+                    println!("My IP config is {:?}", config);
+                    println!("Lets connect");
+                    let mut sock = wifi_interface.network_stack().socket().unwrap();
+                    let addr =
+                        SocketAddrV4::new(embedded_nal::Ipv4Addr::new(142, 250, 185, 115), 80);
+                    wifi_interface
+                        .network_stack()
+                        .connect(&mut sock, addr.into())
+                        .unwrap();
 
-                        socket = Some(sock);
-                        stage = 1;
-                        println!("Lets send");
-                    }
-                    1 => {
-                        if network_stack
-                            .send(
-                                &mut socket.unwrap(),
-                                &b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n"[..],
-                            )
-                            .is_ok()
-                        {
-                            stage = 2;
-                            println!("Lets receive");
-                        }
-                    }
-                    2 => {
-                        if let Ok(s) =
-                            network_stack.receive(&mut socket.unwrap(), &mut buffer[idx..])
-                        {
-                            if s > 0 {
-                                idx += s;
-                            }
-                        } else {
-                            stage = 3;
-
-                            for c in &buffer[..idx] {
-                                esp_wifi::print!("{}", *c as char);
-                            }
-                            println!("");
-                        }
-                    }
-                    3 => {
-                        println!("Close");
-                        network_stack.close(socket.unwrap()).ok();
-                        stage = 4;
-                    }
-                    4 => {
-                        waiter -= 1;
-                        if waiter == 0 {
-                            idx = 0;
-                            waiter = 50000;
-                            stage = 0;
-                        }
-                    }
-                    _ => (),
+                    socket = Some(sock);
+                    stage = 1;
+                    println!("Lets send");
                 }
+                1 => {
+                    if wifi_interface
+                        .network_stack()
+                        .send(
+                            &mut socket.unwrap(),
+                            &b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n"[..],
+                        )
+                        .is_ok()
+                    {
+                        stage = 2;
+                        println!("Lets receive");
+                    }
+                }
+                2 => {
+                    if let Ok(s) = wifi_interface
+                        .network_stack()
+                        .receive(&mut socket.unwrap(), &mut buffer[idx..])
+                    {
+                        if s > 0 {
+                            idx += s;
+                        }
+                    } else {
+                        stage = 3;
+
+                        for c in &buffer[..idx] {
+                            esp_wifi::print!("{}", *c as char);
+                        }
+                        println!("");
+                    }
+                }
+                3 => {
+                    println!("Close");
+                    wifi_interface.network_stack().close(socket.unwrap()).ok();
+                    stage = 4;
+                }
+                4 => {
+                    waiter -= 1;
+                    if waiter == 0 {
+                        idx = 0;
+                        waiter = 50000;
+                        stage = 0;
+                    }
+                }
+                _ => (),
             }
-        }
-    }
-}
-
-#[allow(dead_code)]
-fn print_scan_result() {
-    unsafe {
-        let mut bss_total: u16 = 0;
-        binary::include::esp_wifi_scan_get_ap_num(&mut bss_total);
-        crate::println!("Found {} APs.", bss_total);
-        if bss_total > 10 {
-            bss_total = 10;
-        }
-
-        crate::println!("...");
-        let mut records = [binary::include::wifi_ap_record_t {
-            bssid: [0u8; 6],
-            ssid: [0u8; 33],
-            primary: 0u8,
-            second: 0u32,
-            rssi: 0i8,
-            authmode: 0u32,
-            pairwise_cipher: 0u32,
-            group_cipher: 0u32,
-            ant: 0u32,
-            _bitfield_align_1: [0u32; 0],
-            _bitfield_1: binary::include::__BindgenBitfieldUnit::new([0u8; 4usize]),
-            country: binary::include::wifi_country_t {
-                cc: [0; 3],
-                schan: 0u8,
-                nchan: 0u8,
-                max_tx_power: 0i8,
-                policy: 0u32,
-            },
-        }; 10];
-
-        crate::println!("calling esp_wifi_scan_get_ap_records");
-        binary::include::esp_wifi_scan_get_ap_records(
-            &mut bss_total,
-            &mut records as *mut binary::include::wifi_ap_record_t,
-        );
-
-        crate::println!("printing {} records", bss_total);
-        for i in 0..bss_total {
-            let record = records[i as usize];
-            let ssid = compat::common::StrBuf::from(&record.ssid as *const u8);
-            crate::println!(
-                "{} {} {:x?} {}",
-                ssid.as_str_ref(),
-                record.rssi,
-                record.bssid,
-                record.primary
-            );
         }
     }
 }

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,26 @@
+use core::alloc::{GlobalAlloc, Layout};
+
+use crate::compat::malloc::{free, malloc};
+
+/// A simple allocator just using the internal `malloc` implementation.
+/// Please note: This currently doesn't honor a non-standard aligment and will silently just use the default.
+pub struct EspAllocator;
+
+unsafe impl GlobalAlloc for EspAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // we don't care about the alignment here
+        malloc(layout.size() as u32) as *mut u8
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        free(ptr as *mut u8);
+    }
+}
+
+#[alloc_error_handler]
+fn alloc_error(layout: Layout) -> ! {
+    panic!("Allocator error {:?}", layout);
+}
+
+#[global_allocator]
+static GLOBAL: EspAllocator = EspAllocator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,38 @@
 #![no_std]
 #![feature(c_variadic)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
+#![feature(alloc_error_handler)]
 
+#[doc(hidden)]
 pub mod binary;
+
+#[doc(hidden)]
 pub mod compat;
+
+#[doc(hidden)]
 pub mod preempt;
+
+#[doc(hidden)]
 pub mod print;
+
+#[doc(hidden)]
 #[cfg_attr(feature = "esp32c3", path = "timer_esp32c3.rs")]
 #[cfg_attr(feature = "esp32", path = "timer_esp32.rs")]
 pub mod timer;
 pub mod wifi;
 
+#[doc(hidden)]
 pub mod tasks;
 
 pub(crate) mod memory_fence;
 
 pub use critical_section;
+
+#[cfg(feature = "allocator")]
+pub mod allocator;
+
+#[cfg(feature = "embedded-svc")]
+pub mod wifi_interface;
 
 extern "C" {
     // ROM functions, see esp32c3-link.x

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -1,3 +1,4 @@
+#[doc(hidden)]
 pub mod os_adapter;
 #[cfg(feature = "esp32")]
 use esp32_hal as hal;
@@ -7,6 +8,8 @@ use esp32_hal::Rng;
 use esp32c3_hal as hal;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal::Rng;
+
+#[doc(hidden)]
 pub use os_adapter::*;
 use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
 #[cfg(feature = "esp32")]
@@ -527,6 +530,7 @@ pub fn wifi_stop() -> i32 {
     unsafe { esp_wifi_stop() }
 }
 
+/// A wifi device implementing smoltcp's Device trait.
 pub struct WifiDevice {}
 
 impl WifiDevice {

--- a/src/wifi/utils.rs
+++ b/src/wifi/utils.rs
@@ -38,6 +38,11 @@ macro_rules! network_stack_storage {
     }};
 }
 
+/// Convenient way to create an `embedded-nal` implementation using `smoltcp-nal`
+/// You can use the provided macros to create and pass a suitable backing storage.
+///
+/// Currently `smoltcp-nal` only implements client stacks. If you need server functionality
+/// you need to fall back to `smoltcp` itself.
 pub fn create_network_stack<'a>(
     storage: (
         &'a mut [SocketStorage<'a>],
@@ -90,6 +95,7 @@ pub fn create_network_stack<'a>(
     network_stack
 }
 
+/// The clock used by `smoltcp-nal`
 pub struct WifiClock {}
 
 impl embedded_time::Clock for WifiClock {

--- a/src/wifi_interface.rs
+++ b/src/wifi_interface.rs
@@ -1,0 +1,238 @@
+use core::fmt::Display;
+
+use embedded_nal::Ipv4Addr;
+use embedded_svc::{
+    ipv4::{ClientSettings, Mask, Subnet},
+    wifi::{
+        AccessPointInfo, ApStatus, AuthMethod, ClientConnectionStatus, ClientIpStatus,
+        ClientStatus, SecondaryChannel, Status,
+    },
+};
+use enumset::EnumSet;
+use smoltcp_nal::NetworkStack;
+
+use crate::wifi::{utils::WifiClock, WifiDevice};
+
+extern crate alloc;
+
+const MAX_SCAN_RESULT: u16 = 10;
+
+/// An implementation of `embedded-svc`'s wifi trait.
+pub struct Wifi<'a> {
+    network_stack: NetworkStack<'a, WifiDevice, WifiClock>,
+    current_config: embedded_svc::wifi::Configuration,
+}
+
+impl<'a> Wifi<'a> {
+    /// Create a new instance from a `NetworkStack`
+    pub fn new(network_stack: NetworkStack<'a, WifiDevice, WifiClock>) -> Wifi<'a> {
+        Wifi {
+            network_stack,
+            current_config: embedded_svc::wifi::Configuration::default(),
+        }
+    }
+
+    /// Get a mutable reference to the `NetworkStack`
+    pub fn network_stack(&mut self) -> &mut NetworkStack<'a, WifiDevice, WifiClock> {
+        &mut self.network_stack
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum WifiError {
+    Unknown(i32),
+}
+
+impl Display for WifiError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<'a> embedded_svc::errors::Errors for Wifi<'a> {
+    type Error = WifiError;
+}
+
+impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
+    /// This currently only supports the `Client` capability.
+    fn get_capabilities(&self) -> Result<EnumSet<embedded_svc::wifi::Capability>, Self::Error> {
+        // for now we only support STA mode
+        let mut caps = EnumSet::empty();
+        caps.insert(embedded_svc::wifi::Capability::Client);
+        Ok(caps)
+    }
+
+    /// Get the wifi status.
+    /// Please note: To ever get into the state of an assigned IP address you need to make sure
+    /// that `poll` is called frequently on the network stack.
+    /// Subnet and DNS - while present under the hood - is unsupported for now.
+    fn get_status(&self) -> Status {
+        match crate::wifi::get_wifi_state() {
+            crate::wifi::WifiState::WifiReady => Status(ClientStatus::Stopped, ApStatus::Stopped),
+            crate::wifi::WifiState::StaStart => Status(ClientStatus::Starting, ApStatus::Stopped),
+            crate::wifi::WifiState::StaStop => Status(ClientStatus::Stopped, ApStatus::Stopped),
+            crate::wifi::WifiState::StaConnected => {
+                let client_ip_status = if let Some(ip) = self.network_stack.interface().ipv4_addr()
+                {
+                    if !ip.is_unspecified() {
+                        let mut ip_bytes: [u8; 4] = [0; 4];
+                        ip_bytes.copy_from_slice(ip.as_bytes());
+
+                        // TODO how to get gateway / mask and nameservers here?
+                        ClientIpStatus::Done(ClientSettings {
+                            ip: Ipv4Addr::from(ip_bytes),
+                            subnet: Subnet {
+                                gateway: Ipv4Addr::new(0, 0, 0, 0),
+                                mask: Mask(24),
+                            },
+                            dns: Some(Ipv4Addr::new(0, 0, 0, 0)),
+                            secondary_dns: Some(Ipv4Addr::new(0, 0, 0, 0)),
+                        })
+                    } else {
+                        ClientIpStatus::Waiting
+                    }
+                } else {
+                    ClientIpStatus::Waiting
+                };
+
+                Status(
+                    ClientStatus::Started(ClientConnectionStatus::Connected(client_ip_status)),
+                    ApStatus::Stopped,
+                )
+            }
+            crate::wifi::WifiState::StaDisconnected => Status(
+                ClientStatus::Started(ClientConnectionStatus::Disconnected),
+                ApStatus::Stopped,
+            ),
+            crate::wifi::WifiState::Invalid => Status(ClientStatus::Stopped, ApStatus::Stopped),
+        }
+    }
+
+    /// A blocking wifi network scan.
+    fn scan(&mut self) -> Result<alloc::vec::Vec<AccessPointInfo>, Self::Error> {
+        crate::wifi::wifi_start_scan();
+
+        let mut scanned = alloc::vec::Vec::new();
+
+        unsafe {
+            let mut bss_total: u16 = 0;
+            crate::binary::include::esp_wifi_scan_get_ap_num(&mut bss_total);
+            if bss_total > MAX_SCAN_RESULT {
+                bss_total = MAX_SCAN_RESULT;
+            }
+
+            let mut records = [crate::binary::include::wifi_ap_record_t {
+                bssid: [0u8; 6],
+                ssid: [0u8; 33],
+                primary: 0u8,
+                second: 0u32,
+                rssi: 0i8,
+                authmode: 0u32,
+                pairwise_cipher: 0u32,
+                group_cipher: 0u32,
+                ant: 0u32,
+                _bitfield_align_1: [0u32; 0],
+                _bitfield_1: crate::binary::include::__BindgenBitfieldUnit::new([0u8; 4usize]),
+                country: crate::binary::include::wifi_country_t {
+                    cc: [0; 3],
+                    schan: 0u8,
+                    nchan: 0u8,
+                    max_tx_power: 0i8,
+                    policy: 0u32,
+                },
+            }; MAX_SCAN_RESULT as usize];
+
+            crate::binary::include::esp_wifi_scan_get_ap_records(
+                &mut bss_total,
+                &mut records as *mut crate::binary::include::wifi_ap_record_t,
+            );
+
+            for i in 0..bss_total {
+                let record = records[i as usize];
+                let ssid_strbuf = crate::compat::common::StrBuf::from(&record.ssid as *const u8);
+
+                let auth_method = match record.authmode {
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_OPEN => AuthMethod::None,
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WEP => AuthMethod::WEP,
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA_PSK => AuthMethod::WPA,
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA2_PSK => {
+                        AuthMethod::WPA2Personal
+                    }
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA_WPA2_PSK => {
+                        AuthMethod::WPAWPA2Personal
+                    }
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA2_ENTERPRISE => {
+                        AuthMethod::WPA2Enterprise
+                    }
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA3_PSK => {
+                        AuthMethod::WPA3Personal
+                    }
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WPA2_WPA3_PSK => {
+                        AuthMethod::WPA2WPA3Personal
+                    }
+                    crate::binary::include::wifi_auth_mode_t_WIFI_AUTH_WAPI_PSK => {
+                        AuthMethod::WAPIPersonal
+                    }
+                    _ => panic!(),
+                };
+
+                let mut ssid = alloc::string::String::new();
+                ssid.push_str(ssid_strbuf.as_str_ref());
+
+                let ap_info = AccessPointInfo {
+                    ssid: ssid,
+                    bssid: record.bssid,
+                    channel: record.primary,
+                    secondary_channel: match record.second {
+                        crate::binary::include::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE => {
+                            SecondaryChannel::None
+                        }
+                        crate::binary::include::wifi_second_chan_t_WIFI_SECOND_CHAN_ABOVE => {
+                            SecondaryChannel::Above
+                        }
+                        crate::binary::include::wifi_second_chan_t_WIFI_SECOND_CHAN_BELOW => {
+                            SecondaryChannel::Below
+                        }
+                        _ => panic!(),
+                    },
+                    signal_strength: record.rssi.abs() as u8,
+                    protocols: EnumSet::empty(), // TODO
+                    auth_method: auth_method,
+                };
+
+                scanned.push(ap_info);
+            }
+        }
+
+        Ok(scanned)
+    }
+
+    /// Get the currently used configuration.
+    fn get_configuration(&self) -> Result<embedded_svc::wifi::Configuration, Self::Error> {
+        Ok(self.current_config.clone())
+    }
+
+    /// Set the configuration and start connecting.
+    /// Currently only `ssid` and `password` is used. Trying anything but `Configuration::Client` will result in a panic!
+    fn set_configuration(
+        &mut self,
+        conf: &embedded_svc::wifi::Configuration,
+    ) -> Result<(), Self::Error> {
+        self.current_config = conf.clone();
+
+        let res = match conf {
+            embedded_svc::wifi::Configuration::None => panic!(),
+            embedded_svc::wifi::Configuration::Client(conf) => {
+                crate::wifi::wifi_connect(&conf.ssid, &conf.password)
+            }
+            embedded_svc::wifi::Configuration::AccessPoint(_) => panic!(),
+            embedded_svc::wifi::Configuration::Mixed(_, _) => panic!(),
+        };
+
+        if res != 0 {
+            Err(WifiError::Unknown(res))
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
This adds optional (partial) support for the _embedded-svc_ wifi trait

Additionally
- optional allocator (which is just using the compat-malloc) - required for _embedded-svc_ wifi trait
- examples are adjusted to use the new wifi trait

It still only supports STA mode. Also, only the assigned IP address is available in `ClientIpStatus`

Please note that building the examples now require the `embedded-svc` feature