### PR TITLE
Implement embedded-svc 0.22.0 wifi trait, fix dhcp example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     // "editor.formatOnSave": true,
     "rust-analyzer.cargo.features": [
-        "esp32",
+        "esp32c3",
         "embedded-svc",
     ],
-    "rust-analyzer.cargo.target": "xtensa-esp32-none-elf",
+    "rust-analyzer.cargo.target": "riscv32imc-unknown-none-elf",
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ riscv-target = { version = "0.1.2", optional = true }
 
 [target.xtensa-esp32-none-elf.dev-dependencies]
 esp-println = { git = "https://github.com/esp-rs/esp-println.git", features = [ "esp32" ] }
-esp-backtrace = { git = "https://github.com/esp-rs/esp-backtrace.git", features = [ "esp32", "panic-handler", "exception-handler" ] }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-backtrace.git", features = [ "esp32", "panic-handler", "exception-handler", "print-uart" ] }
 
 [target.riscv32imc-unknown-none-elf.dev-dependencies]
 esp-println = { git = "https://github.com/esp-rs/esp-println.git", features = [ "esp32c3" ] }
-esp-backtrace = { git = "https://github.com/esp-rs/esp-backtrace.git", features = [ "esp32c3", "panic-handler", "exception-handler" ] }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-backtrace.git", features = [ "esp32c3", "panic-handler", "exception-handler", "print-uart" ] }
 
 [dev-dependencies]
 ble-hci = { git = "https://github.com/bjoernQ/ble-hci", branch = "embedded-io" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ smoltcp = { version = "0.8.0", default-features=false, features = ["proto-igmp",
 critical-section = "0.2.7"
 atomic-polyfill = "0.1.7"
 log = "0.4.17"
-embedded-svc = { version = "0.21.2", default-features = false, features = [ "alloc" ], optional = true }
+embedded-svc = { version = "0.22.0", default-features = false, features = [], optional = true }
 enumset = { version = "1", default-features = false, optional = true }
 esp-alloc = { git = "https://github.com/esp-rs/esp-alloc", branch = "legacy" }
 embedded-io = "0.3.0"
 fugit = "0.3.6"
+heapless = { version = "0.7.14", default-features = false }
 
 [build-dependencies]
 riscv-target = { version = "0.1.2", optional = true }

--- a/examples/dhcp_esp32/main.rs
+++ b/examples/dhcp_esp32/main.rs
@@ -45,8 +45,8 @@ fn main() -> ! {
     println!("{:?}", wifi_interface.get_status());
 
     println!("Start Wifi Scan");
-    let res = wifi_interface.scan();
-    if let Ok(res) = res {
+    let res = wifi_interface.scan_n::<10>();
+    if let Ok((res, _count)) = res {
         for ap in res {
             println!("{:?}", ap);
         }
@@ -149,7 +149,7 @@ fn main() -> ! {
                         .network_interface()
                         .get_socket::<TcpSocket>(http_socket_handle.unwrap());
 
-                    socket.close();
+                    socket.abort();
                     stage = 4;
                 }
                 4 => {

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -528,8 +528,8 @@ pub fn wifi_start() -> i32 {
 
 pub fn wifi_start_scan() -> i32 {
     let scan_time = wifi_scan_time_t {
-        active: wifi_active_scan_time_t { min: 0, max: 0 },
-        passive: 0,
+        active: wifi_active_scan_time_t { min: 10, max: 20 },
+        passive: 20,
     };
 
     let scan_config = wifi_scan_config_t {

--- a/src/wifi_interface.rs
+++ b/src/wifi_interface.rs
@@ -188,6 +188,7 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
 
         let mut scanned = heapless::Vec::<AccessPointInfo, N>::new();
         let mut bss_total: u16 = N as u16;
+        let total;
 
         unsafe {
             crate::binary::include::esp_wifi_scan_get_ap_num(&mut bss_total);
@@ -218,7 +219,8 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
                 &mut records as *mut crate::binary::include::wifi_ap_record_t,
             );
 
-            for i in 0..bss_total {
+            total = usize::min(bss_total as usize, N);
+            for i in 0..total {
                 let record = records[i as usize];
                 let ssid_strbuf = crate::compat::common::StrBuf::from(&record.ssid as *const u8);
 
@@ -275,7 +277,7 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
             }
         }
 
-        Ok((scanned, bss_total as usize))
+        Ok((scanned, total))
     }
 
     /// Get the currently used configuration.

--- a/src/wifi_interface.rs
+++ b/src/wifi_interface.rs
@@ -19,8 +19,6 @@ use crate::wifi::WifiDevice;
 
 extern crate alloc;
 
-const MAX_SCAN_RESULT: u16 = 10;
-
 /// An implementation of `embedded-svc`'s wifi trait.
 pub struct Wifi<'a> {
     network_interface: Interface<'a, WifiDevice>,
@@ -116,11 +114,9 @@ impl Display for WifiError {
     }
 }
 
-impl<'a> embedded_svc::errors::Errors for Wifi<'a> {
-    type Error = WifiError;
-}
-
 impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
+    type Error = WifiError;
+
     /// This currently only supports the `Client` capability.
     fn get_capabilities(&self) -> Result<EnumSet<embedded_svc::wifi::Capability>, Self::Error> {
         // for now we only support STA mode
@@ -185,17 +181,16 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
     }
 
     /// A blocking wifi network scan.
-    fn scan(&mut self) -> Result<alloc::vec::Vec<AccessPointInfo>, Self::Error> {
+    fn scan_n<const N: usize>(
+        &mut self,
+    ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error> {
         crate::wifi::wifi_start_scan();
 
-        let mut scanned = alloc::vec::Vec::new();
+        let mut scanned = heapless::Vec::<AccessPointInfo, N>::new();
+        let mut bss_total: u16 = N as u16;
 
         unsafe {
-            let mut bss_total: u16 = 0;
             crate::binary::include::esp_wifi_scan_get_ap_num(&mut bss_total);
-            if bss_total > MAX_SCAN_RESULT {
-                bss_total = MAX_SCAN_RESULT;
-            }
 
             let mut records = [crate::binary::include::wifi_ap_record_t {
                 bssid: [0u8; 6],
@@ -216,7 +211,7 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
                     max_tx_power: 0i8,
                     policy: 0u32,
                 },
-            }; MAX_SCAN_RESULT as usize];
+            }; N];
 
             crate::binary::include::esp_wifi_scan_get_ap_records(
                 &mut bss_total,
@@ -252,8 +247,8 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
                     _ => panic!(),
                 };
 
-                let mut ssid = alloc::string::String::new();
-                ssid.push_str(ssid_strbuf.as_str_ref());
+                let mut ssid = heapless::String::<30>::new();
+                ssid.push_str(ssid_strbuf.as_str_ref()).ok();
 
                 let ap_info = AccessPointInfo {
                     ssid: ssid,
@@ -276,11 +271,11 @@ impl<'a> embedded_svc::wifi::Wifi for Wifi<'a> {
                     auth_method: auth_method,
                 };
 
-                scanned.push(ap_info);
+                scanned.push(ap_info).ok();
             }
         }
 
-        Ok(scanned)
+        Ok((scanned, bss_total as usize))
     }
 
     /// Get the currently used configuration.


### PR DESCRIPTION
- updates `embedded-svc` to _0.22.0_
- introduces the changes needed for that
- makes the _dhcp_ example more robust
