### PR TITLE
Adapt to ESP32-C3 interrupt changes

### DIFF
--- a/examples/ble_esp32c3/main.rs
+++ b/examples/ble_esp32c3/main.rs
@@ -35,12 +35,7 @@ fn main() -> ! {
     rtc_cntl.set_super_wdt_enable(false);
     rtc_cntl.set_wdt_enable(false);
 
-    initialize_ble(
-        &mut peripherals.SYSTIMER,
-        &mut peripherals.INTERRUPT_CORE0,
-        peripherals.RNG,
-    )
-    .unwrap();
+    initialize_ble(&mut peripherals.SYSTIMER, peripherals.RNG).unwrap();
 
     println!("before ble init");
     ble_init();
@@ -109,11 +104,6 @@ fn main() -> ! {
             }
         }
     }
-}
-
-#[export_name = "DefaultHandler"]
-pub fn default_handler() {
-    println!("DefaultHandler called!");
 }
 
 pub fn init_logger() {

--- a/examples/dhcp_esp32c3/main.rs
+++ b/examples/dhcp_esp32c3/main.rs
@@ -42,12 +42,7 @@ fn main() -> ! {
     let ethernet = create_network_interface(network_stack_storage!(storage));
     let mut wifi_interface = esp_wifi::wifi_interface::Wifi::new(ethernet);
 
-    initialize(
-        &mut peripherals.SYSTIMER,
-        &mut peripherals.INTERRUPT_CORE0,
-        peripherals.RNG,
-    )
-    .unwrap();
+    initialize(&mut peripherals.SYSTIMER, peripherals.RNG).unwrap();
 
     println!("{:?}", wifi_interface.get_status());
 
@@ -172,11 +167,6 @@ fn main() -> ! {
             }
         }
     }
-}
-
-#[export_name = "DefaultHandler"]
-pub fn default_handler() {
-    println!("DefaultHandler called!");
 }
 
 pub fn init_logger() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ use timer::{get_systimer_count, TICKS_PER_SECOND};
 #[cfg(feature = "embedded-svc")]
 pub mod wifi_interface;
 
+#[cfg(feature = "esp32c3")]
+use esp32c3_hal::interrupt;
+
 pub fn current_millis() -> u64 {
     get_systimer_count() / TICKS_PER_SECOND
 }

--- a/src/timer_esp32c3.rs
+++ b/src/timer_esp32c3.rs
@@ -60,9 +60,6 @@ pub fn setup_timer_isr(systimer: &mut SYSTIMER) {
 #[interrupt]
 fn WIFI_MAC() {
     unsafe {
-        let intr = &*pac::INTERRUPT_CORE0::ptr();
-        intr.cpu_int_clear.write(|w| w.bits(1 << 1));
-
         let (fnc, arg) = crate::wifi::os_adapter::ISR_INTERRUPT_1;
 
         trace!("interrupt WIFI_MAC {:p} {:p}", fnc, arg);

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -81,12 +81,11 @@ static mut BLE_ENABLED: bool = false;
 /// This will initialize internals and also initialize WiFi
 pub fn initialize(
     systimer: &mut esp32c3_hal::pac::SYSTIMER,
-    interrupt_core0: &mut esp32c3_hal::pac::INTERRUPT_CORE0,
     rng: hal::pac::RNG,
 ) -> Result<(), WifiError> {
     init_rng(rng);
     init_tasks();
-    setup_timer_isr(systimer, interrupt_core0);
+    setup_timer_isr(systimer);
     wifi_set_log_verbose();
     init_clocks();
     init_buffer();
@@ -107,12 +106,11 @@ pub fn initialize(
 /// This will just initialize internals.
 pub fn initialize_ble(
     systimer: &mut esp32c3_hal::pac::SYSTIMER,
-    interrupt_core0: &mut esp32c3_hal::pac::INTERRUPT_CORE0,
     rng: hal::pac::RNG,
 ) -> Result<(), WifiError> {
     init_rng(rng);
     init_tasks();
-    setup_timer_isr(systimer, interrupt_core0);
+    setup_timer_isr(systimer);
     wifi_set_log_verbose();
     init_clocks();
     init_buffer();

--- a/src/wifi/os_adapter_esp32c3.rs
+++ b/src/wifi/os_adapter_esp32c3.rs
@@ -91,19 +91,27 @@ pub(crate) unsafe extern "C" fn set_intr(
         intr_prio
     );
 
+    // this gets called with
+    // INFO - set_intr 0 2 1 1 (WIFI_PWR)
+    // INFO - set_intr 0 0 1 1 (WIFI_MAC)
+
+    // we do nothing here anymore since all the interrupts are already
+    // configured in `setup_timer_isr` and messing with the interrupts will
+    // get us into trouble
+
     // esp32c3_bind_irq(intr_num, intr_source, intr_prio, ESP32C3_INT_LEVEL);
 
     /* Disable the CPU interrupt. */
     // resetbits(1 << cpuint, INTERRUPT_CPU_INT_ENABLE_REG);
 
     /* Set the interrupt priority. */
-    ((0x600c2000 + 0x114 + intr_num * 4) as *mut u32).write_volatile(intr_prio as u32);
+    //  ((0x600c2000 + 0x114 + intr_num * 4) as *mut u32).write_volatile(intr_prio as u32);
 
     /* Set the interrupt type (Edge or Level). */
     // ----
 
     /* Map the CPU interrupt ID to the peripheral. */
-    ((0x600c2000 + intr_source * 4) as *mut u32).write_volatile(intr_num as u32);
+    //  ((0x600c2000 + intr_source * 4) as *mut u32).write_volatile(intr_num as u32);
 }
 
 pub(crate) unsafe extern "C" fn phy_enable() {


### PR DESCRIPTION
This adds the necessary changes to make `esp-wifi` work again on top of the current `esp-hal`