### PR TITLE
Fix order of magnitude error when creating timestamp

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod wifi_interface;
 use esp32c3_hal::interrupt;
 
 pub fn current_millis() -> u64 {
-    get_systimer_count() / TICKS_PER_SECOND
+    get_systimer_count() / (TICKS_PER_SECOND / 1000)
 }
 
 // TODO: should the below code live somewhere else, in its own module maybe? Or is it fine here?


### PR DESCRIPTION
I've been trying to improve the reliability of esp-wifi and found something peculiar when I was creating a DNS example in https://github.com/esp-rs/esp-wifi/tree/example/dns-query for @JurajSadel, it would take nearly 10 minutes to resolve the DNS query, which was very odd.

I looked a bit deeper and it turned out that the timestamping mechanism was increasing _one millisecond_ per _second_ meaning any timeout would be 1000 times longer than it should be! With this fix, provided the WiFi actually connects to the AP, I can reliably get an IP from DHCP and run through the stages loop. Even on my crappy powerline router which takes 15~ seconds to respond to DHCP.

@jessebraham I think this might fix some issues for you. Possibly fixes https://github.com/esp-rs/esp-wifi/issues/38 too? Would you mind trying with this very small patch, @D1plo1d?

Sadly the AP connection can sometimes still fail but I haven't had a chance to look into that, it may just be a case of having to retry the connection sometimes.

