### PR TITLE
Use HAL dependencies from crates.io, use HAL's systimer for ESP32-C3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 embedded-hal = "0.2.3"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
-esp32c3-hal = { package="esp32c3-hal", git = "https://github.com/esp-rs/esp-hal", optional = true }
-esp32-hal = { package="esp32-hal", git = "https://github.com/esp-rs/esp-hal", optional = true, features = [ "bluetooth","rt" ] }
+esp32c3-hal = { version = "0.1.0", optional = true }
+esp32-hal = { version = "0.4.0", optional = true, features = [ "bluetooth","rt" ] }
 riscv-rt = { version = "0.9.0", optional = true }
 riscv = { version = "0.8.0", optional = true }
 xtensa-lx-rt = { version = "0.13.0", optional = true }

--- a/examples/ble_esp32c3/main.rs
+++ b/examples/ble_esp32c3/main.rs
@@ -11,6 +11,7 @@ use ble_hci::{
     attribute_server::{AttributeServer, Service, WorkResult, ATT_READABLE, ATT_WRITEABLE},
     Ble, Data, HciConnector,
 };
+use esp32c3_hal::systimer::SystemTimer;
 use esp32c3_hal::{
     clock::{ClockControl, CpuClock},
     pac::Peripherals,
@@ -33,7 +34,7 @@ fn main() -> ! {
     init_logger();
     esp_wifi::init_heap();
 
-    let mut peripherals = Peripherals::take().unwrap();
+    let peripherals = Peripherals::take().unwrap();
     let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
 
@@ -43,7 +44,9 @@ fn main() -> ! {
     rtc.swd.disable();
     rtc.rwdt.disable();
 
-    initialize_ble(&mut peripherals.SYSTIMER, peripherals.RNG, &clocks).unwrap();
+    let syst = SystemTimer::new(peripherals.SYSTIMER);
+
+    initialize_ble(syst.alarm0, peripherals.RNG, &clocks).unwrap();
 
     println!("before ble init");
     ble_init();

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -7,6 +7,8 @@ use esp32_hal::Rng;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal as hal;
 #[cfg(feature = "esp32c3")]
+use esp32c3_hal::systimer::{Alarm, Target};
+#[cfg(feature = "esp32c3")]
 use esp32c3_hal::Rng;
 
 use fugit::MegahertzU32;
@@ -78,7 +80,7 @@ static mut BLE_ENABLED: bool = false;
 /// Initialize for using WiFi
 /// This will initialize internals and also initialize WiFi
 pub fn initialize(
-    systimer: &mut esp32c3_hal::pac::SYSTIMER,
+    systimer: Alarm<Target, 0>,
     rng: hal::pac::RNG,
     clocks: &Clocks,
 ) -> Result<(), WifiError> {
@@ -108,7 +110,7 @@ pub fn initialize(
 /// Initialize for using Bluetooth LE
 /// This will just initialize internals.
 pub fn initialize_ble(
-    systimer: &mut esp32c3_hal::pac::SYSTIMER,
+    systimer: Alarm<Target, 0>,
     rng: hal::pac::RNG,
     clocks: &Clocks,
 ) -> Result<(), WifiError> {


### PR DESCRIPTION
- use HAL's systimer implementation on ESP32-C3 now that we have support for periodic timers
- prefer critical_section::Mutex over SpinLockMutex
- use the published HALs from crates.io

Closes #13 