### PR TITLE
Use another BLE stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [profile.release]
-opt-level = "s"
+opt-level = 3
 
 [dependencies]
 embedded-hal = "0.2.3"
@@ -34,7 +34,8 @@ heapless = { version = "0.7.14", default-features = false }
 riscv-target = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
-ble-hci = { git = "https://github.com/bjoernQ/ble-hci", branch = "embedded-io" }
+bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps" }
+bleps-macros = { git = "https://github.com/bjoernQ/bleps", package = "bleps-macros" }
 
 [target.xtensa-esp32-none-elf.dev-dependencies]
 esp-println = { version = "0.3.1", features = [ "esp32", "log" ] }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit 8e5147d2de8d9b9
 
 - ble
     - starts Bluetooth advertising
-    - offers two services (one is read/write, one is write only)
+    - offers one service with two characteristics (one is read/write, one is write only)
     - this uses a toy level BLE stack - might not work with every BLE central device (tested with Android and Windows Bluetooth LE Explorer)
 
 - coex (ESP32-C3 only)

--- a/examples/ble.rs
+++ b/examples/ble.rs
@@ -8,14 +8,15 @@ use esp32_hal as hal;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal as hal;
 
-use ble_hci::{
+use bleps::{
     ad_structure::{
         create_advertising_data, AdStructure, BR_EDR_NOT_SUPPORTED, LE_GENERAL_DISCOVERABLE,
     },
-    att::Uuid,
-    attribute_server::{AttributeServer, Service, WorkResult, ATT_READABLE, ATT_WRITEABLE},
-    Ble, Data, HciConnector,
+    attribute_server::{AttributeServer, WorkResult},
+    Ble, HciConnector,
 };
+use bleps_macros::gatt;
+
 use esp_backtrace as _;
 use esp_println::{logger::init_logger, println};
 use esp_wifi::{ble::controller::BleConnector, initialize};
@@ -101,31 +102,25 @@ fn main() -> ! {
             println!("RECEIVED: {:x?}", data.to_slice());
         };
 
-        let srv1 = Service::new(
-            Uuid::Uuid128([
-                0xC9, 0x15, 0x15, 0x96, 0x54, 0x56, 0x64, 0xB3, 0x38, 0x45, 0x26, 0x5D, 0xF1, 0x62,
-                0x6A, 0xA8,
-            ]),
-            ATT_READABLE | ATT_WRITEABLE,
-            &mut rf,
-            &mut wf,
-        );
-
-        let mut rf2 = || Data::default();
         let mut wf2 = |_data| {};
 
-        let srv2 = Service::new(
-            Uuid::Uuid128([
-                0xC8, 0x15, 0x15, 0x96, 0x54, 0x56, 0x64, 0xB3, 0x38, 0x45, 0x26, 0x5D, 0xF1, 0x62,
-                0x6A, 0xA8,
-            ]),
-            ATT_WRITEABLE,
-            &mut rf2,
-            &mut wf2,
-        );
+        gatt!([
+        service {
+            uuid: "937312e0-2354-11eb-9f10-fbc30a62cf38",
+            characteristics: [
+                characteristic {
+                    uuid: "937312e0-2354-11eb-9f10-fbc30a62cf38",
+                    read: rf,
+                    write: wf,
+                },
+                characteristic {
+                    uuid: "957312e0-2354-11eb-9f10-fbc30a62cf38",
+                    write: wf2,
+                },
+            ],
+        },]);
 
-        let services = &mut [srv1, srv2];
-        let mut srv = AttributeServer::new(&mut ble, services);
+        let mut srv = AttributeServer::new(&mut ble, &mut gatt_attributes);
 
         loop {
             match srv.do_work() {

--- a/examples/coex.rs
+++ b/examples/coex.rs
@@ -8,13 +8,15 @@ use esp32_hal as hal;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal as hal;
 
-use ble_hci::{
+use bleps::{
     ad_structure::{
         create_advertising_data, AdStructure, BR_EDR_NOT_SUPPORTED, LE_GENERAL_DISCOVERABLE,
     },
-    att::Uuid,
-    Ble, HciConnector,
+    attribute_server::{AttributeServer, WorkResult},
+    Ble, Data, HciConnection, HciConnector, att::Uuid,
 };
+use bleps_macros::gatt;
+
 use esp_wifi::{ble::controller::BleConnector, current_millis, wifi_interface::Network};
 
 use embedded_io::blocking::*;

--- a/examples/dhcp.rs
+++ b/examples/dhcp.rs
@@ -21,8 +21,8 @@ use embedded_svc::wifi::{
 use esp_backtrace as _;
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::utils::{create_network_interface};
-use esp_wifi::wifi_interface::{timestamp, WifiError, Network};
+use esp_wifi::wifi::utils::create_network_interface;
+use esp_wifi::wifi_interface::{timestamp, Network, WifiError};
 use esp_wifi::{create_network_stack_storage, network_stack_storage};
 use esp_wifi::{current_millis, initialize};
 use hal::clock::{ClockControl, CpuClock};


### PR DESCRIPTION
This replaces the older toy BLE stack with another toy BLE stack.

Reason is
- the new one is nicer to use
- I plan to publish the new one on crates.io someday, so we can publish esp-wifi

