### PR TITLE
Removed global allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ atomic-polyfill = "1.0.1"
 log = "0.4.17"
 embedded-svc = { version = "0.22.1", default-features = false, features = [], optional = true }
 enumset = { version = "1", default-features = false, optional = true }
-esp-alloc = { version = "0.1.0", features = ["oom-handler"] }
 embedded-io = "0.3.0"
 fugit = "0.3.6"
 heapless = { version = "0.7.14", default-features = false }

--- a/src/compat/malloc.rs
+++ b/src/compat/malloc.rs
@@ -1,12 +1,13 @@
-use core::alloc::{GlobalAlloc, Layout};
+extern crate alloc;
+use alloc::alloc as alloc_m;
 
-use crate::ALLOCATOR;
+use core::alloc::Layout;
 
 pub unsafe extern "C" fn malloc(size: u32) -> *const u8 {
     log::trace!("alloc {}", size);
 
     let total_size = size as usize + 4;
-    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4));
+    let ptr = alloc_m::alloc(Layout::from_size_align_unchecked(total_size, 4));
     *(ptr as *mut _ as *mut usize) = total_size;
     ptr.offset(4)
 }
@@ -20,7 +21,7 @@ pub unsafe extern "C" fn free(ptr: *const u8) {
 
     let ptr = ptr.offset(-4);
     let total_size = *(ptr as *const usize);
-    ALLOCATOR.dealloc(
+    alloc_m::dealloc(
         ptr as *mut u8,
         Layout::from_size_align_unchecked(total_size, 4),
     );
@@ -31,7 +32,7 @@ pub unsafe extern "C" fn calloc(number: u32, size: u32) -> *const u8 {
     log::trace!("calloc {} {}", number, size);
 
     let total_size = (number * size) as usize + 4;
-    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4)) as *mut u8;
+    let ptr = alloc_m::alloc(Layout::from_size_align_unchecked(total_size, 4)) as *mut u8;
     core::ptr::write_bytes::<u8>(ptr, 0u8, total_size);
     *(ptr as *mut _ as *mut usize) = total_size;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,33 +63,6 @@ pub fn current_millis() -> u64 {
     get_systimer_count() / (TICKS_PER_SECOND / 1000)
 }
 
-// TODO: should the below code live somewhere else, in its own module maybe? Or is it fine here?
-
-#[global_allocator]
-pub(crate) static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
-
-pub fn init_heap() {
-    #[cfg(not(coex))]
-    const HEAP_SIZE: usize = 64 * 1024;
-
-    #[cfg(coex)]
-    const HEAP_SIZE: usize = 96 * 1024;
-
-    extern "C" {
-        static mut _heap_start: u32;
-        //static mut _heap_end: u32; // XXX we don't have it on ESP32-C3 currently
-    }
-
-    unsafe {
-        let heap_start = &_heap_start as *const _ as usize;
-
-        //let heap_end = &_heap_end as *const _ as usize;
-        //assert!(heap_end - heap_start > HEAP_SIZE, "Not enough available heap memory.");
-
-        ALLOCATOR.init(heap_start as *mut u8, HEAP_SIZE);
-    }
-}
-
 #[cfg(feature = "esp32c3")]
 /// Initialize for using WiFi / BLE
 /// This will initialize internals and also initialize WiFi and BLE


### PR DESCRIPTION
Removes the global allocator, so users can provide their own.

TODO: Need to update the examples since they must provide their own allocator now.