### PR TITLE
Remove global allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [profile.release]
-opt-level = 1
+opt-level = 3
 
 [dependencies]
 embedded-hal = "0.2.3"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
 esp32c3-hal = { version = "0.2.0", optional = true }
-esp32-hal = { version = "0.5.0", optional = true, features = [ "bluetooth","rt" ] }
+esp32-hal = { version = "0.5.0", optional = true, features = [ "rt" ] }
 esp32s3-hal = { version = "0.2.0", optional = true, features = [ "rt" ] }
 esp32s2-hal = { version = "0.2.0", optional = true, features = [ "rt" ] }
 riscv-rt = { version = "0.9.0", optional = true }
@@ -66,7 +66,7 @@ utils = []
 enumset = []
 embedded-svc = [ "dep:enumset", "dep:embedded-svc", "utils" ]
 wifi = []
-ble = []
+ble = [ "esp32-hal?/bluetooth" ]
 
 # currently published versions don't contain all relevant adjustments - using git dependencies for now
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [profile.release]
-opt-level = 3
+opt-level = 1
 
 [dependencies]
 embedded-hal = "0.2.3"
@@ -25,7 +25,7 @@ atomic-polyfill = "1.0.1"
 log = "0.4.17"
 embedded-svc = { version = "0.22.1", default-features = false, features = [], optional = true }
 enumset = { version = "1", default-features = false, optional = true }
-esp-alloc = { version = "0.1.0", features = ["oom-handler"] }
+linked_list_allocator = { version = "0.10.3", default-features = false, features = ["const_mut_refs"] }
 embedded-io = "0.3.0"
 fugit = "0.3.6"
 heapless = { version = "0.7.14", default-features = false }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ This is even more experimental than support for ESP32-C3.
 On ESP32 / ESP32-S3 currently TIMG1/TIMER0 is used as the main timer so you can't use it for anything else.
 Additionally it uses CCOMPARE0 - so don't touch that, too.
 
+## opt-level for Xtensa targets
+
+Currently your mileage might vary a lot for different opt-levels on Xtensa targets!
+If something doesn't work as expected try a different opt-level.
+
 ## Directory Structure
 
 - `src/timer-espXXX.rs`: systimer code used for timing and task switching

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit 839bcd7cb89d695
 | `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`              | ESP32   |
 | `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`             | ESP32   |
 | `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`             | ESP32-S3|
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`             | ESP32-S2|
+| `CARGO_PROFILE_RELEASE_OPT_LEVEL=1 cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`             | ESP32-S2|
 
 Additional you can specify these features
 |Feature|Meaning|
@@ -85,6 +85,8 @@ Additionally it uses CCOMPARE0 - so don't touch that, too.
 
 Currently your mileage might vary a lot for different opt-levels on Xtensa targets!
 If something doesn't work as expected try a different opt-level.
+
+e.g. that's why the ESP32-S2 example needs to be built with `opt-level=2`
 
 ## Directory Structure
 

--- a/examples/ble.rs
+++ b/examples/ble.rs
@@ -35,8 +35,6 @@ use riscv_rt::entry;
 #[cfg(feature = "esp32")]
 use xtensa_lx_rt::entry;
 
-extern crate alloc;
-
 #[entry]
 fn main() -> ! {
     init_logger(log::LevelFilter::Info);

--- a/examples/coex.rs
+++ b/examples/coex.rs
@@ -42,8 +42,6 @@ use riscv_rt::entry;
 #[cfg(feature = "esp32")]
 use xtensa_lx_rt::entry;
 
-extern crate alloc;
-
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 

--- a/examples/dhcp.rs
+++ b/examples/dhcp.rs
@@ -37,8 +37,6 @@ use riscv_rt::entry;
 #[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
 use xtensa_lx_rt::entry;
 
-extern crate alloc;
-
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 

--- a/src/compat/malloc.rs
+++ b/src/compat/malloc.rs
@@ -1,12 +1,21 @@
-use core::alloc::{GlobalAlloc, Layout};
+use core::alloc::Layout;
 
-use crate::ALLOCATOR;
+use crate::HEAP;
 
 pub unsafe extern "C" fn malloc(size: u32) -> *const u8 {
     log::trace!("alloc {}", size);
 
     let total_size = size as usize + 4;
-    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4));
+
+    let layout = Layout::from_size_align_unchecked(total_size, 4);
+    let ptr = critical_section::with(|cs| {
+        HEAP.borrow(cs)
+            .borrow_mut()
+            .allocate_first_fit(layout)
+            .ok()
+            .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
+    });
+
     *(ptr as *mut _ as *mut usize) = total_size;
     ptr.offset(4)
 }
@@ -20,20 +29,19 @@ pub unsafe extern "C" fn free(ptr: *const u8) {
 
     let ptr = ptr.offset(-4);
     let total_size = *(ptr as *const usize);
-    ALLOCATOR.dealloc(
-        ptr as *mut u8,
-        Layout::from_size_align_unchecked(total_size, 4),
-    );
+
+    let layout = Layout::from_size_align_unchecked(total_size, 4);
+    critical_section::with(|cs| {
+        HEAP.borrow(cs)
+            .borrow_mut()
+            .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), layout)
+    });
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn calloc(number: u32, size: u32) -> *const u8 {
     log::trace!("calloc {} {}", number, size);
 
-    let total_size = (number * size) as usize + 4;
-    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4)) as *mut u8;
-    core::ptr::write_bytes::<u8>(ptr, 0u8, total_size);
-    *(ptr as *mut _ as *mut usize) = total_size;
-
-    ptr.offset(4) as *const u8
+    let total_size = number * size + 4;
+    malloc(total_size)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ const HEAP_SIZE: usize = 64 * 1024;
 #[cfg(coex)]
 const HEAP_SIZE: usize = 96 * 1024;
 
-static mut HEAP_DATA: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::new(0u8); HEAP_SIZE];
+static mut HEAP_DATA: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
 
 pub(crate) static HEAP: Mutex<RefCell<Heap>> = Mutex::new(RefCell::new(Heap::empty()));
 

--- a/src/preempt/preempt_riscv.rs
+++ b/src/preempt/preempt_riscv.rs
@@ -15,7 +15,7 @@ const MAX_TASK: usize = 4;
 #[cfg(not(coex))]
 const MAX_TASK: usize = 3;
 
-static mut TASK_STACK: [u8; STACK_SIZE * MAX_TASK] = [0u8; STACK_SIZE * MAX_TASK];
+static mut TASK_STACK: [u8; STACK_SIZE * (MAX_TASK - 1)] = [0u8; STACK_SIZE * (MAX_TASK - 1)];
 
 pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
 

--- a/src/preempt/preempt_xtensa.rs
+++ b/src/preempt/preempt_xtensa.rs
@@ -14,7 +14,7 @@ const MAX_TASK: usize = 4;
 #[cfg(not(coex))]
 const MAX_TASK: usize = 3;
 
-static mut TASK_STACK: [u8; STACK_SIZE * MAX_TASK] = [0x0u8; STACK_SIZE * MAX_TASK];
+static mut TASK_STACK: [u8; STACK_SIZE * (MAX_TASK - 1)] = [0x0u8; STACK_SIZE * (MAX_TASK - 1)];
 
 pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
 

--- a/src/wifi_interface.rs
+++ b/src/wifi_interface.rs
@@ -20,8 +20,6 @@ use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address};
 use crate::current_millis;
 use crate::wifi::WifiDevice;
 
-extern crate alloc;
-
 /// An implementation of `embedded-svc`'s wifi trait.
 pub struct Wifi<'a> {
     network_interface: Interface<'a, WifiDevice>,


### PR DESCRIPTION
Previously esp-wifi contained its own global allocator (for no real reason) which prevented users from using their own allocator or none at all.

Instead of the allocator it now uses `linked-list-allocator` directly with an array placed in `.bss` 

This PR also contains these smaller changes
- improved BLE implementation (by not doing just nothing on interrupt-enable/disable)
- on ESP32 the Bluetooth RAM feature is only activated when the BLE feature is activated
