### PR TITLE
Fix the newest ESP-HAL's Alarm's method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,6 @@ ble = [ "esp32-hal?/bluetooth" ]
 
 # currently published versions don't contain all relevant adjustments - using git dependencies for now
 [patch.crates-io]
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32s3-hal", rev = "af745ac7b0799752260e13573895b97153d85639" }
-esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32s2-hal", rev = "af745ac7b0799752260e13573895b97153d85639" }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32c3-hal", rev = "af745ac7b0799752260e13573895b97153d85639" }
+esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32s3-hal", rev = "9b3e644e309e0ab3332fd007f4ac2fb4881abc4c" }
+esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32s2-hal", rev = "9b3e644e309e0ab3332fd007f4ac2fb4881abc4c" }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal/", package = "esp32c3-hal", rev = "9b3e644e309e0ab3332fd007f4ac2fb4881abc4c" }

--- a/src/timer_esp32c3.rs
+++ b/src/timer_esp32c3.rs
@@ -19,7 +19,7 @@ pub fn setup_timer_isr(systimer: Alarm<Target, 0>) {
     let alarm0 = systimer.into_periodic();
     alarm0.set_period(TIMER_DELAY.into());
     alarm0.clear_interrupt();
-    alarm0.enable_interrupt();
+    alarm0.interrupt_enable(true);
 
     esp32c3_hal::interrupt::enable(
         Interrupt::SYSTIMER_TARGET0,

--- a/src/timer_esp32s2.rs
+++ b/src/timer_esp32s2.rs
@@ -5,7 +5,7 @@ use critical_section::Mutex;
 use esp32s2_hal::{
     interrupt,
     pac::{self, TIMG1},
-    prelude::_embedded_hal_timer_CountDown,
+    prelude::{Instance, _embedded_hal_timer_CountDown},
     timer::{Timer, Timer0},
 };
 use log::trace;

--- a/src/timer_esp32s3.rs
+++ b/src/timer_esp32s3.rs
@@ -5,7 +5,7 @@ use critical_section::Mutex;
 use esp32s3_hal::{
     interrupt,
     pac::{self, TIMG1},
-    prelude::_embedded_hal_timer_CountDown,
+    prelude::{Instance, _embedded_hal_timer_CountDown},
     timer::{Timer, Timer0},
 };
 use log::trace;


### PR DESCRIPTION
Fix the newest ESP-HAL's Alarm's method: [interrupt_enable](https://github.com/esp-rs/esp-hal/blob/9b3e644e309e0ab3332fd007f4ac2fb4881abc4c/esp-hal-common/src/systimer.rs#L81)