### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ opt-level = 3
 embedded-hal = "0.2.3"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
-esp32c3-hal = { version = "0.3.0", optional = true }
-esp32-hal = { version = "0.6.0", optional = true, features = [ "rt" ] }
-esp32s3-hal = { version = "0.3.0", optional = true, features = [ "rt" ] }
-esp32s2-hal = { version = "0.3.0", optional = true, features = [ "rt" ] }
+esp32c3-hal = { version = "0.4.0", optional = true }
+esp32-hal = { version = "0.7.0", optional = true, features = [ "rt" ] }
+esp32s3-hal = { version = "0.4.0", optional = true, features = [ "rt" ] }
+esp32s2-hal = { version = "0.4.0", optional = true, features = [ "rt" ] }
 riscv-rt = { version = "0.10.0", optional = true }
 riscv = { version = "0.10.0", optional = true }
 xtensa-lx-rt = { version = "0.14.0", optional = true }
@@ -67,10 +67,3 @@ enumset = []
 embedded-svc = [ "dep:enumset", "dep:embedded-svc", "utils" ]
 wifi = []
 ble = [ "esp32-hal?/bluetooth" ]
-
-[patch.crates-io]
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", package = "esp-hal-common", rev = "4ab05e89235e620287a6c3b24486c0b8c2c05a28" }
-esp32-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32-hal", rev = "4ab05e89235e620287a6c3b24486c0b8c2c05a28" }
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32s3-hal", rev = "4ab05e89235e620287a6c3b24486c0b8c2c05a28" }
-esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32s2-hal", rev = "4ab05e89235e620287a6c3b24486c0b8c2c05a28" }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32c3-hal", rev = "4ab05e89235e620287a6c3b24486c0b8c2c05a28" }

--- a/src/preempt/mod.rs
+++ b/src/preempt/mod.rs
@@ -1,3 +1,33 @@
+use atomic_polyfill::*;
+
+pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
+
+static mut TASK_TOP: usize = 0;
+
+static mut CTX_NOW: usize = 0;
+
+macro_rules! sum {
+    ($h:expr) => ($h);
+    ($h:expr, $($t:expr),*) =>
+        ($h + sum!($($t),*));
+}
+
+macro_rules! task_stack {
+    ($($task_stack_size:literal),+) => {
+        const TASKS_COUNT: usize = [$($task_stack_size),+].len();
+        const TASK_STACK_SIZE: [usize; TASKS_COUNT] = [$($task_stack_size),+];
+        const TOTAL_STACK_SIZE: usize = sum!($($task_stack_size),+);
+        static mut TASK_STACK: [u8; TOTAL_STACK_SIZE] = [0u8; TOTAL_STACK_SIZE];
+        const MAX_TASK: usize = [$($task_stack_size),+].len() + 1;
+    };
+}
+
+#[cfg(coex)]
+task_stack!(8192, 8192, 8192);
+
+#[cfg(not(coex))]
+task_stack!(8192, 8192);
+
 #[cfg_attr(target_arch = "riscv32", path = "preempt_riscv.rs")]
 #[cfg_attr(target_arch = "xtensa", path = "preempt_xtensa.rs")]
 pub mod preempt;

--- a/src/timer_esp32.rs
+++ b/src/timer_esp32.rs
@@ -69,9 +69,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
         );
     }
 
-    while unsafe {
-        crate::preempt::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed)
-    } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
 }
 
 #[cfg(feature = "ble")]

--- a/src/timer_esp32c3.rs
+++ b/src/timer_esp32c3.rs
@@ -57,9 +57,7 @@ pub fn setup_timer_isr(systimer: Alarm<Target, 0>) {
         riscv::interrupt::enable();
     }
 
-    while unsafe {
-        crate::preempt::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed)
-    } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
 }
 
 #[cfg(feature = "wifi")]

--- a/src/timer_esp32s2.rs
+++ b/src/timer_esp32s2.rs
@@ -62,9 +62,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
         );
     }
 
-    while unsafe {
-        crate::preempt::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed)
-    } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
 }
 
 #[allow(non_snake_case)]

--- a/src/timer_esp32s3.rs
+++ b/src/timer_esp32s3.rs
@@ -69,9 +69,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
         );
     }
 
-    while unsafe {
-        crate::preempt::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed)
-    } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
 }
 
 #[cfg(feature = "ble")]


### PR DESCRIPTION
This updates the HAL versions to the currently published ones. 

Additionally, it decreases the stack size of the tasks - I tested with the examples and it seems fine so hopefully things keep working for everyone

Closes #9 

In theory we can now have different stack sizes per task but I guess having all of them 8k should be fine
