### PR TITLE
BTLE for ESP32-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This is experimental and work-in-progress! You are welcome to experiment with it
 
 WiFi / BTLE coexistence is implemented but currently only works (to some extend) on ESP32-C3. In general COEX shouldn't be used currently.
 
-On ESP32-S3 only WiFi is currently supported.
-
 Minimum supported Rust compiler version: 1.65.0.0
 
 This uses the WiFi drivers from https://github.com/esp-rs/esp-wireless-drivers-3rdparty
@@ -53,12 +51,13 @@ https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit 839bcd7cb89d695
 | `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`                                | ESP32   |
 | `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                 | ESP32   |
 | `cargo "+esp" run --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`            | ESP32   |
+| `cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"`                                | ESP32-S3 |
 | `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`             | ESP32-S3|
 | `cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`        | ESP32-S3|
 | `cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`             | ESP32-S2|
 | `cargo "+esp" run --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`        | ESP32-S2|
 
-Additional you can specify these features
+Additionally you can specify these features
 |Feature|Meaning|
 |---|---|
 |wifi_logs|logs the WiFi logs from the driver at log level info|

--- a/build.rs
+++ b/build.rs
@@ -32,10 +32,6 @@ fn main() -> Result<(), String> {
         return Err("You need to use feature `wifi` and/or `ble`".to_string());
     }
 
-    if cfg!(feature = "esp32s3") && cfg!(feature = "ble") {
-        return Err("BLE is not yet supported for ESP32-S3".into());
-    }
-
     if cfg!(feature = "esp32s2") && cfg!(feature = "ble") {
         return Err("BLE is not supported for ESP32-S2".into());
     }
@@ -192,6 +188,8 @@ fn handle_chip() {
         "esp32s3_rom_functions.x",
     );
 
+    copy(out, include_bytes!("libs/esp32s3/libbtbb.a"), "libbtbb.a");
+
     copy(
         out,
         include_bytes!("libs/esp32s3/libbtdm_app.a"),
@@ -228,6 +226,7 @@ fn handle_chip() {
         "libwpa_supplicant.a",
     );
 
+    println!("cargo:rustc-link-lib={}", "btbb");
     println!("cargo:rustc-link-lib={}", "btdm_app");
     println!("cargo:rustc-link-lib={}", "coexist");
     println!("cargo:rustc-link-lib={}", "core");

--- a/examples/ble.rs
+++ b/examples/ble.rs
@@ -7,6 +7,8 @@
 use esp32_hal as hal;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal as hal;
+#[cfg(feature = "esp32s3")]
+use esp32s3_hal as hal;
 
 use bleps::{
     ad_structure::{
@@ -27,12 +29,12 @@ use hal::{
     Rng, Rtc,
 };
 
-#[cfg(feature = "esp32c3")]
+#[cfg(any(feature = "esp32", feature = "esp32s3"))]
 use hal::system::SystemExt;
 
 #[cfg(feature = "esp32c3")]
 use riscv_rt::entry;
-#[cfg(feature = "esp32")]
+#[cfg(any(feature = "esp32", feature = "esp32s3"))]
 use xtensa_lx_rt::entry;
 
 #[entry]
@@ -49,7 +51,7 @@ fn main() -> ! {
 
     #[cfg(feature = "esp32c3")]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
-    #[cfg(feature = "esp32")]
+    #[cfg(any(feature = "esp32", feature = "esp32s3"))]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
@@ -66,7 +68,7 @@ fn main() -> ! {
         let syst = SystemTimer::new(peripherals.SYSTIMER);
         initialize(syst.alarm0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
-    #[cfg(feature = "esp32")]
+    #[cfg(any(feature = "esp32", feature = "esp32s3"))]
     {
         use hal::timer::TimerGroup;
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
@@ -89,6 +91,8 @@ fn main() -> ! {
                 AdStructure::CompleteLocalName("ESP32-C3 BLE"),
                 #[cfg(feature = "esp32")]
                 AdStructure::CompleteLocalName("ESP32 BLE"),
+                #[cfg(feature = "esp32s3")]
+                AdStructure::CompleteLocalName("ESP32-S3 BLE"),
             ]))
         );
         println!("{:?}", ble.cmd_set_le_advertise_enable(true));

--- a/examples/coex.rs
+++ b/examples/coex.rs
@@ -7,6 +7,8 @@
 use esp32_hal as hal;
 #[cfg(feature = "esp32c3")]
 use esp32c3_hal as hal;
+#[cfg(feature = "esp32s3")]
+use esp32s3_hal as hal;
 
 use bleps::{
     ad_structure::{
@@ -40,7 +42,7 @@ use hal::system::SystemExt;
 
 #[cfg(feature = "esp32c3")]
 use riscv_rt::entry;
-#[cfg(feature = "esp32")]
+#[cfg(any(feature = "esp32", feature = "esp32s3"))]
 use xtensa_lx_rt::entry;
 
 const SSID: &str = env!("SSID");
@@ -60,7 +62,7 @@ fn main() -> ! {
 
     #[cfg(feature = "esp32c3")]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock160MHz).freeze();
-    #[cfg(feature = "esp32")]
+    #[cfg(any(feature = "esp32", feature = "esp32s3"))]
     let clocks = ClockControl::configure(system.clock_control, CpuClock::Clock240MHz).freeze();
 
     let mut rtc = Rtc::new(peripherals.RTC_CNTL);
@@ -81,7 +83,7 @@ fn main() -> ! {
         let syst = SystemTimer::new(peripherals.SYSTIMER);
         initialize(syst.alarm0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
-    #[cfg(feature = "esp32")]
+    #[cfg(any(feature = "esp32", feature = "esp32s3"))]
     {
         use hal::timer::TimerGroup;
         let timg1 = TimerGroup::new(peripherals.TIMG1, &clocks);
@@ -158,6 +160,8 @@ fn main() -> ! {
             AdStructure::CompleteLocalName("ESP32-C3 BLE"),
             #[cfg(feature = "esp32")]
             AdStructure::CompleteLocalName("ESP32 BLE"),
+            #[cfg(feature = "esp32s3")]
+            AdStructure::CompleteLocalName("ESP32-S3 BLE"),
         ]))
     );
     println!("{:?}", ble.cmd_set_le_advertise_enable(true));

--- a/src/ble/os_adapter_esp32s3.rs
+++ b/src/ble/os_adapter_esp32s3.rs
@@ -1,0 +1,166 @@
+use crate::binary::include::esp_bt_controller_config_t;
+use log::trace;
+
+pub static mut ISR_INTERRUPT_5: (
+    *mut crate::binary::c_types::c_void,
+    *mut crate::binary::c_types::c_void,
+) = (core::ptr::null_mut(), core::ptr::null_mut());
+
+pub static mut ISR_INTERRUPT_8: (
+    *mut crate::binary::c_types::c_void,
+    *mut crate::binary::c_types::c_void,
+) = (core::ptr::null_mut(), core::ptr::null_mut());
+
+extern "C" {
+    fn btdm_controller_rom_data_init() -> i32;
+}
+
+pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
+    esp_bt_controller_config_t {
+        magic: 0x5A5AA5A5,
+        version: 0x02112280,
+        controller_task_stack_size: 8192,
+        controller_task_prio: 200,
+        controller_task_run_cpu: 0,
+        bluetooth_mode: 1,
+        ble_max_act: 10,
+        sleep_mode: 0,
+        sleep_clock: 0,
+        ble_st_acl_tx_buf_nb: 0,
+        ble_hw_cca_check: 0,
+        ble_adv_dup_filt_max: 30,
+        coex_param_en: false,
+        ce_len_type: 0,
+        coex_use_hooks: false,
+        hci_tl_type: 1,
+        hci_tl_funcs: core::ptr::null_mut(),
+        txant_dft: 0,
+        rxant_dft: 0,
+        txpwr_dft: 9,
+        cfg_mask: 1,
+        scan_duplicate_mode: 0,
+        scan_duplicate_type: 0,
+        normal_adv_size: 20,
+        mesh_adv_size: 0,
+        coex_phy_coded_tx_rx_time_limit: 0,
+        hw_target_code: 0x02010000, // BLE_HW_TARGET_CODE_ESP32S3_CHIP_ECO0
+        slave_ce_len_min: 5,
+        hw_recorrect_en: 1 << 0,
+        cca_thresh: 20,
+    }
+}
+
+pub(crate) unsafe extern "C" fn interrupt_on(intr_num: i32) {
+    log::trace!("interrupt_on {}", intr_num);
+    unsafe {
+        xtensa_lx::interrupt::enable_mask(1 << 1);
+    }
+}
+
+pub(crate) unsafe extern "C" fn interrupt_off(_intr_num: i32) {
+    todo!();
+}
+
+pub(crate) fn btdm_controller_mem_init() {
+    unsafe {
+        btdm_controller_rom_data_init();
+    }
+}
+
+pub(crate) fn bt_periph_module_enable() {
+    // nothing
+}
+
+pub(crate) fn disable_sleep_mode() {
+    // nothing
+}
+
+// OSI functions
+
+pub(crate) unsafe extern "C" fn interrupt_set(
+    cpu_no: i32,
+    intr_source: i32,
+    interrupt_no: i32,
+    interrupt_prio: i32,
+) {
+    log::trace!(
+        "interrupt_set {} {} {} {}",
+        cpu_no,
+        intr_source,
+        interrupt_no,
+        interrupt_prio
+    );
+}
+
+pub(crate) unsafe extern "C" fn interrupt_clear(_interrupt_source: i32, _interrupt_no: i32) {
+    todo!();
+}
+
+pub(crate) unsafe extern "C" fn interrupt_handler_set(
+    interrupt_no: i32,
+    func: extern "C" fn(),
+    arg: *const (),
+) {
+    trace!(
+        "interrupt_handler_set {} {:p} {:p}",
+        interrupt_no,
+        func,
+        arg
+    );
+    match interrupt_no {
+        5 => {
+            ISR_INTERRUPT_5 = (
+                func as *mut crate::binary::c_types::c_void,
+                arg as *mut crate::binary::c_types::c_void,
+            )
+        }
+        8 => {
+            ISR_INTERRUPT_8 = (
+                func as *mut crate::binary::c_types::c_void,
+                arg as *mut crate::binary::c_types::c_void,
+            )
+        }
+        _ => panic!("Unsupported interrupt number {}", interrupt_no),
+    }
+}
+
+pub(crate) unsafe extern "C" fn coex_wifi_sleep_set(sleep: i32) {
+    log::debug!(
+        "ignored coex_wifi_sleep_set {} - because original implementation does the same",
+        sleep
+    );
+}
+
+#[allow(unused_variables, dead_code)]
+pub(crate) unsafe extern "C" fn coex_core_ble_conn_dyn_prio_get(
+    low: *mut i32,
+    high: *mut i32,
+) -> i32 {
+    extern "C" {
+        fn coex_core_ble_conn_dyn_prio_get(low: *mut i32, high: *mut i32) -> i32;
+    }
+    log::debug!("coex_core_ble_conn_dyn_prio_get");
+
+    #[cfg(coex)]
+    return coex_core_ble_conn_dyn_prio_get(low, high);
+
+    #[cfg(not(coex))]
+    0
+}
+
+pub(crate) unsafe extern "C" fn esp_hw_power_down() {
+    todo!();
+}
+
+pub(crate) unsafe extern "C" fn esp_hw_power_up() {
+    todo!();
+}
+
+pub(crate) unsafe extern "C" fn ets_backup_dma_copy(
+    _reg: u32,
+    _mem_addr: u32,
+    _num: u32,
+    _to_rem: i32,
+) {
+    todo!();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,18 @@ pub fn initialize(
         return Err(InitializationError::WrongClockConfig);
     }
 
+    #[cfg(feature = "esp32s3")]
+    unsafe {
+        // should be done by the HAL in `ClockControl::configure`
+        const ETS_UPDATE_CPU_FREQUENCY: u32 = 0x40001a4c;
+
+        // cast to usize is just needed because of the way we run clippy in CI
+        let rom_ets_update_cpu_frequency: fn(ticks_per_us: u32) =
+            core::mem::transmute(ETS_UPDATE_CPU_FREQUENCY as usize);
+
+        rom_ets_update_cpu_frequency(240); // we know it's 240MHz because of the check above
+    }
+
     phy_mem_init();
     init_rng(rng);
     init_tasks();

--- a/src/timer_esp32.rs
+++ b/src/timer_esp32.rs
@@ -50,7 +50,6 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     #[cfg(feature = "ble")]
     {
         interrupt::enable(pac::Interrupt::RWBT, interrupt::Priority::Priority1).unwrap();
-        interrupt::enable(pac::Interrupt::RWBLE, interrupt::Priority::Priority1).unwrap();
         interrupt::enable(pac::Interrupt::BT_BB, interrupt::Priority::Priority1).unwrap();
     }
 

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -110,6 +110,25 @@ static mut G_COEX_ADAPTER_FUNCS: coex_adapter_funcs_t = coex_adapter_funcs_t {
     _magic: crate::binary::include::COEX_ADAPTER_MAGIC as i32,
 };
 
+#[cfg(all(feature = "esp32s3", coex))]
+static mut G_COEX_ADAPTER_FUNCS: coex_adapter_funcs_t = coex_adapter_funcs_t {
+    _version: crate::binary::include::COEX_ADAPTER_VERSION as i32,
+    _task_yield_from_isr: Some(task_yield_from_isr),
+    _semphr_create: Some(semphr_create),
+    _semphr_delete: Some(semphr_delete),
+    _semphr_take_from_isr: Some(semphr_take_from_isr_wrapper),
+    _semphr_give_from_isr: Some(semphr_give_from_isr_wrapper),
+    _semphr_take: Some(semphr_take),
+    _semphr_give: Some(semphr_give),
+    _is_in_isr: Some(is_in_isr_wrapper),
+    _malloc_internal: Some(malloc),
+    _free: Some(free),
+    _esp_timer_get_time: Some(esp_timer_get_time),
+    _env_is_chip: Some(env_is_chip),
+    _slowclk_cal_get: Some(slowclk_cal_get),
+    _magic: crate::binary::include::COEX_ADAPTER_MAGIC as i32,
+};
+
 #[cfg(all(feature = "esp32", coex))]
 static mut G_COEX_ADAPTER_FUNCS: coex_adapter_funcs_t = coex_adapter_funcs_t {
     _version: crate::binary::include::COEX_ADAPTER_VERSION as i32,

--- a/src/wifi/os_adapter.rs
+++ b/src/wifi/os_adapter.rs
@@ -2066,9 +2066,17 @@ pub unsafe extern "C" fn coex_schm_curr_phase_idx_get() -> crate::binary::c_type
 pub unsafe extern "C" fn slowclk_cal_get() -> u32 {
     trace!("slowclk_cal_get");
 
+    // TODO not hardcode this
+
     #[cfg(feature = "esp32s2")]
     return 44462;
 
-    #[cfg(not(feature = "esp32s2"))]
+    #[cfg(feature = "esp32s3")]
+    return 44462;
+
+    #[cfg(feature = "esp32c3")]
     return 28639;
+
+    #[cfg(feature = "esp32")]
+    return 28639;    
 }


### PR DESCRIPTION
- implements BTLE support for ESP32-S3
- fixes #78 - not sure why not enabling the RWBLE interrupt fixes this but for me I haven't seen that assert triggered anymore
- coex is implemented but only works in opt-level 1 (seems there are still mis-optimizations going on - no idea how to find out what the problem might be) ... that's why coex on ESP32-S3 isn't mentioned in the README

