### PR TITLE
Wifi device refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ linked_list_allocator = { version = "0.10.3", default-features = false, features
 embedded-io = "0.3.1"
 fugit = "0.3.6"
 heapless = { version = "0.7.14", default-features = false }
+num-derive = { version = "0.3", features = ["full-syntax"] }
+num-traits = { version = "0.2", default-features = false }
 
 [build-dependencies]
 riscv-target = { version = "0.1.2", optional = true }

--- a/examples/coex.rs
+++ b/examples/coex.rs
@@ -27,8 +27,7 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::{logger::init_logger, print, println};
 use esp_wifi::initialize;
-use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi_interface::WifiError;
+use esp_wifi::wifi::{WifiError, utils::create_network_interface};
 use esp_wifi::{create_network_stack_storage, network_stack_storage};
 use hal::{
     clock::{ClockControl, CpuClock},

--- a/examples/dhcp.rs
+++ b/examples/dhcp.rs
@@ -21,8 +21,8 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi_interface::{Network, WifiError};
+use esp_wifi::wifi::{WifiError, utils::create_network_interface};
+use esp_wifi::wifi_interface::Network;
 use esp_wifi::{create_network_stack_storage, network_stack_storage};
 use esp_wifi::{current_millis, initialize};
 use hal::clock::{ClockControl, CpuClock};

--- a/examples/static_ip.rs
+++ b/examples/static_ip.rs
@@ -21,8 +21,8 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::logger::init_logger;
 use esp_println::{print, println};
-use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi_interface::{Network, WifiError};
+use esp_wifi::wifi::{WifiError, utils::create_network_interface};
+use esp_wifi::wifi_interface::Network;
 use esp_wifi::{create_network_stack_storage, network_stack_storage};
 use esp_wifi::{current_millis, initialize};
 use hal::clock::{ClockControl, CpuClock};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use hal::*;
 use fugit::MegahertzU32;
 use hal::clock::Clocks;
 use linked_list_allocator::Heap;
+use wifi::WifiError;
 
 use crate::common_adapter::init_rng;
 use crate::tasks::init_tasks;
@@ -135,14 +136,8 @@ pub fn initialize(
     {
         log::debug!("wifi init");
         // wifi init
-        let res = crate::wifi::wifi_init();
-        if res != 0 {
-            return Err(InitializationError::General(res));
-        }
-        let res = crate::wifi::wifi_start();
-        if res != 0 {
-            return Err(InitializationError::General(res));
-        }
+        crate::wifi::wifi_init()?;
+        crate::wifi::wifi_start()?;
     }
 
     #[cfg(feature = "ble")]
@@ -160,7 +155,14 @@ pub fn initialize(
 #[derive(Debug, Clone, Copy)]
 pub enum InitializationError {
     General(i32),
+    WifiError(WifiError),
     WrongClockConfig,
+}
+
+impl From<WifiError> for InitializationError {
+    fn from(value: WifiError) -> Self {
+        InitializationError::WifiError(value)
+    }
 }
 
 #[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
@@ -206,14 +208,8 @@ pub fn initialize(
     #[cfg(feature = "wifi")]
     {
         log::debug!("wifi init");
-        let res = crate::wifi::wifi_init();
-        if res != 0 {
-            return Err(InitializationError::General(res));
-        }
-        let res = crate::wifi::wifi_start();
-        if res != 0 {
-            return Err(InitializationError::General(res));
-        }
+        crate::wifi::wifi_init()?;
+        crate::wifi::wifi_start()?;
     }
 
     #[cfg(feature = "ble")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use hal::*;
 use fugit::MegahertzU32;
 use hal::clock::Clocks;
 use linked_list_allocator::Heap;
+#[cfg(feature = "wifi")]
 use wifi::WifiError;
 
 use crate::common_adapter::init_rng;
@@ -155,10 +156,12 @@ pub fn initialize(
 #[derive(Debug, Clone, Copy)]
 pub enum InitializationError {
     General(i32),
+    #[cfg(feature = "wifi")]
     WifiError(WifiError),
     WrongClockConfig,
 }
 
+#[cfg(feature = "wifi")]
 impl From<WifiError> for InitializationError {
     fn from(value: WifiError) -> Self {
         InitializationError::WifiError(value)

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -98,6 +98,34 @@ pub enum WifiError {
     WrongClockConfig,
     Disconnected,
 }
+#[repr(i32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(FromPrimitive)]
+pub enum WifiEvent {
+    WifiEventWifiReady = 0,           
+    WifiEventScanDone,                
+    WifiEventStaStart,                
+    WifiEventStaStop,                 
+    WifiEventStaConnected,            
+    WifiEventStaDisconnected,         
+    WifiEventStaAuthmodeChange,      
+    WifiEventStaWpsErSuccess,       
+    WifiEventStaWpsErFailed,        
+    WifiEventStaWpsErTimeout,       
+    WifiEventStaWpsErPin,           
+    WifiEventStaWpsErPbcOverlap,   
+    WifiEventApStart,                 
+    WifiEventApStop,                  
+    WifiEventApStaconnected,          
+    WifiEventApStadisconnected,       
+    WifiEventApProbereqrecved,        
+    WifiEventFtmReport,               
+    WifiEventStaBssRssiLow,         
+    WifiEventActionTxStatus,         
+    WifiEventRocDone,                 
+    WifiEventStaBeaconTimeout,       
+    WifiEventMax,                      
+}
 
 #[repr(i32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -503,11 +503,7 @@ pub fn wifi_init() -> Result<(), WifiError> {
 
         #[cfg(coex)]
         {
-            let res = coex_init();
-            if res != 0 {
-                log::error!("coex_init failed");
-                return res;
-            }
+            esp_wifi_result!(coex_init())?;
         }
 
         esp_wifi_result!(esp_wifi_init_internal(&G_CONFIG))?;

--- a/src/wifi/mod.rs
+++ b/src/wifi/mod.rs
@@ -888,6 +888,11 @@ impl embedded_svc::wifi::Wifi for WifiDevice {
                     max_tx_power: 0i8,
                     policy: 0u32,
                 },
+                he_ap: crate::binary::include::wifi_he_ap_info_t {
+                    _bitfield_align_1: [0u8; 0],
+                    _bitfield_1: crate::binary::include::wifi_he_ap_info_t::new_bitfield_1(0, 0, 0),
+                    bssid_index: 0,
+                },
             }; N];
 
             crate::binary::include::esp_wifi_scan_get_ap_records(

--- a/src/wifi/os_adapter.rs
+++ b/src/wifi/os_adapter.rs
@@ -905,7 +905,11 @@ pub unsafe extern "C" fn event_post(
         wifi_event_t_WIFI_EVENT_STA_STOP => true,
         wifi_event_t_WIFI_EVENT_STA_CONNECTED => true,
         wifi_event_t_WIFI_EVENT_STA_DISCONNECTED => true,
-        _ => false,
+        _ => {
+            use num_traits::FromPrimitive;
+            log::info!("Unhandled event: {:?}", crate::wifi::WifiEvent::from_i32(event_id));
+            false
+        },
     };
 
     if take_state {


### PR DESCRIPTION
Currently, the `WifiDevice` Is heavily tied to the smoltcp stack. This PR implements `embedded_svc::wifi::Wifi` on the raw device instead of on the stack to allow usage of other stacks (i.e embassy_net). I have included an implementation that just calls the inner device functions for compatibility but I can remove that if needed. Finally, I added the internal error codes from esp-idf and reworked the error types slightly. I'm sure we could get Bingen to generate this for us, but we only really need it for a few things so I just hand-rolled it for now.