### PR TITLE
Add CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,12 +7,12 @@ rustflags = [
 
     "-C", "force-frame-pointers",
 ]
- 
+
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --monitor"
 
 rustflags = [
-    #"-C", "linker=rust-lld",    
+    #"-C", "linker=rust-lld",
 
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Tesp32_rom_functions.x",
@@ -22,7 +22,7 @@ rustflags = [
 runner = "espflash flash --monitor"
 
 rustflags = [
-    #"-C", "linker=rust-lld",    
+    #"-C", "linker=rust-lld",
 
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Tesp32s3_rom_functions.x",
@@ -32,8 +32,8 @@ rustflags = [
 runner = "espflash flash --monitor"
 
 rustflags = [
-    #"-C", "linker=rust-lld",    
-    
+    #"-C", "linker=rust-lld",
+
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Tesp32s2_rom_functions.x",
 
@@ -50,6 +50,6 @@ rustflags = [
 
 [build]
 target = "riscv32imc-unknown-none-elf"
- 
+
 [unstable]
 build-std = [ "core" ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SSID: SSID
+  PASSWORD: PASSWORD
+  STATIC_IP: STATIC_IP
+  GATEWAY_IP: GATEWAY_IP
 
 jobs:
   example-checks:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   rust-checks:
-    name: cargo ${{ matrix.action.command }} - ${{ matrix.board }} (alloc=${{ matrix.alloc }})
+    name: cargo ${{ matrix.action.command }} - ${{ matrix.config.features }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,11 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
       - name: cargo ${{ matrix.action.command }}
-        run: ${{ matrix.config.lto-profile }} cargo +${{ matrix.config.channel }} --features ${{ matrix.config.features }} --target ${{ matrix.config.target }} --release
+        if: matrix.action.command == 'build'
+        run: ${{ matrix.config.lto-profile }} cargo +${{ matrix.config.channel }} ${{ matrix.action.command }} --features ${{ matrix.config.features }} --target ${{ matrix.config.target }} ${{ matrix.action.args }}
+      - name: cargo ${{ matrix.action.command }}
+        if: matrix.action.command == 'fmt'
+        run: cargo +${{ matrix.config.channel }} ${{ matrix.action.command }} ${{ matrix.action.args }}
   example-checks:
     env:
       SSID: SSID

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: esp-rs/xtensa-toolchain@v1.5
         with:
           default: true
-          buildtargets: ${{ matrix.board }}
+          buildtargets: ${{ matrix.config.board }}
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
       - name: cargo ${{ matrix.action.command }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,76 @@
+---
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/README.md"
+  pull_request:
+    paths-ignore:
+      - "**/README.md"
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  example-checks:
+    name: Check examples
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        action:
+          - arg: --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c3,ble"
+            toolchain: nightly
+          - arg: --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"
+            toolchain: nightly
+          - arg: --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"
+            toolchain: nightly
+          - arg: --example coex --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi,ble"
+            toolchain: nightly
+          - arg: --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"
+            toolchain: esp
+          - arg: --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"
+            toolchain: esp
+          - arg: --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"
+            toolchain: esp
+          - arg: --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"
+            toolchain: esp
+          - arg: --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"
+            toolchain: esp
+          - arg: --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"
+            toolchain: esp
+          - arg: --example coex --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi,ble"
+            toolchain: esp
+          - arg: --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"
+            toolchain: esp
+            profile: CARGO_PROFILE_RELEASE_OPT_LEVEL=2
+          - arg: --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"
+            toolchain: esp
+            profile: CARGO_PROFILE_RELEASE_OPT_LEVEL=2
+          - arg: --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"
+            toolchain: nightly
+          - arg: --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"
+            toolchain: nightly
+          - arg: --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"
+            toolchain: nightly
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Rust nightly toolchain
+        if: ${{ matrix.action.toolchain == 'nightly' }}
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Setup Rust esp toolchain
+        if: ${{ matrix.action.toolchain == 'esp' }}
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          ldproxy: false
+      - name: Enable caching
+        uses: Swatinem/rust-cache@v2
+      - name: Cargo command
+        run: cargo build ${{ matrix.action.arg }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,73 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SSID: SSID
-  PASSWORD: PASSWORD
-  STATIC_IP: STATIC_IP
-  GATEWAY_IP: GATEWAY_IP
 
 jobs:
+  rust-checks:
+    name: cargo ${{ matrix.action.command }} - ${{ matrix.board }} (alloc=${{ matrix.alloc }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - target: riscv32imc-unknown-none-elf
+            features: esp32c3,embedded-svc,wifi,ble
+            channel: nightly
+          - target: xtensa-esp32-none-elf
+            board: esp32
+            features: esp32,embedded-svc,wifi
+            channel: esp
+          - target: xtensa-esp32-none-elf
+            board: esp32
+            features: esp32,ble
+            channel: esp
+          - target: xtensa-esp32s3-none-elf
+            board: esp32s3
+            features: esp32s3,embedded-svc,wifi,ble
+            channel: esp
+          - target: xtensa-esp32s2-none-elf
+            board: esp32s2
+            features: esp32s2,embedded-svc,wifi
+            channel: esp
+          - target: riscv32imc-unknown-none-elf
+            features: esp32c2,embedded-svc,wifi
+            channel: nightly
+          - target: riscv32imc-unknown-none-elf
+            features: esp32c2,ble
+            lto-profile: CARGO_PROFILE_RELEASE_LTO=false
+            channel: nightly
+        action:
+          - command: build
+            args: --release
+          - command: fmt
+            args: -- --check
+          # - command: clippy
+          #   args: --no-deps
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup | RISC-V Rust
+        if: matrix.config.target == 'riscv32imc-unknown-none-elf'
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imc-unknown-none-elf
+          toolchain: nightly
+          components: clippy, rustfmt, rust-src
+      - name: Setup | Xtensa Rust
+        if: matrix.config.target != 'riscv32imc-unknown-none-elf'
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          buildtargets: ${{ matrix.board }}
+          ldproxy: false
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo ${{ matrix.action.command }}
+        run: ${{ matrix.condig.lto-profile }} cargo +${{ matrix.condig.channel }} --features ${{ matrix.config.features }} --target ${{ matrix.config.target }} --release
   example-checks:
+    env:
+      SSID: SSID
+      PASSWORD: PASSWORD
+      STATIC_IP: STATIC_IP
+      GATEWAY_IP: GATEWAY_IP
     name: Check examples
     runs-on: ubuntu-20.04
     strategy:
@@ -61,7 +121,6 @@ jobs:
             toolchain: nightly
           - arg: --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"
             toolchain: nightly
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Rust nightly toolchain
         if: ${{ matrix.action.toolchain == 'nightly' }}
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imc-unknown-none-elf
+          toolchain: nightly
+          components: clippy, rustfmt, rust-src
       - name: Setup Rust esp toolchain
         if: ${{ matrix.action.toolchain == 'esp' }}
         uses: esp-rs/xtensa-toolchain@v1.5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
       - name: cargo ${{ matrix.action.command }}
-        run: ${{ matrix.condig.lto-profile }} cargo +${{ matrix.condig.channel }} --features ${{ matrix.config.features }} --target ${{ matrix.config.target }} --release
+        run: ${{ matrix.config.lto-profile }} cargo +${{ matrix.config.channel }} --features ${{ matrix.config.features }} --target ${{ matrix.config.target }} --release
   example-checks:
     env:
       SSID: SSID

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ v5.1-dev-2658-g0025915dc4 commit 0025915dc489a9d45f99aed74920346f8ac4ec09
 
 https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit f4caebff200e8f6f51b0a11d2b69ca56c76bb1c9)
 
+## Current support
+
+If a cell contains am em dash (&mdash;) this means that the particular feature is not present for a chip. A check mark (✓) means that some driver implementation exists. An empty cell means that the feature is present in the chip but not implemented yet.
+
+|          | Wifi  |  BLE  |  Coex   |
+| :------: | :---: | :---: | :-----: |
+|  ESP32   |   ✓   |   ✓   |         |
+| ESP32-S2 |   ✓   |       | &mdash; |
+| ESP32-S3 |   ✓   |   ✓   |    ✓    |
+| ESP32-C3 |   ✓   |   ✓   |    ✓    |
+| ESP32-C2 |   ✓   |   ✓   |         |
+
 ## Examples
 
 - dhcp
@@ -44,34 +56,34 @@ https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit f4caebff200e8f6
   - does BLE advertising
   - coex support is still somewhat flaky
 
-| Command                                                                                                                         | Chip    |
-| ------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c3,ble"`                    | ESP32-C3|
-| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`     | ESP32-C3|
-| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`| ESP32-C3|
-| `cargo "+nightly" run --example coex --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi,ble"` | ESP32-C3|
-| `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`                                | ESP32   |
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                 | ESP32   |
-| `cargo "+esp" run --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`            | ESP32   |
-| `cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"`                                | ESP32-S3 |
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`             | ESP32-S3|
-| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`        | ESP32-S3|
-| `cargo "+esp" run --example coex --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi,ble"`        | ESP32-S3|
-| `CARGO_PROFILE_RELEASE_OPT_LEVEL=2 cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`             | ESP32-S2|
-| `CARGO_PROFILE_RELEASE_OPT_LEVEL=2 cargo "+esp" run --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`        | ESP32-S2|
-| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"`                    | ESP32-C2|
-| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`     | ESP32-C2|
-| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`| ESP32-C2|
+| Command                                                                                                                                                    | Chip     |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c3,ble"`                                               | ESP32-C3 |
+| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`                                | ESP32-C3 |
+| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`                           | ESP32-C3 |
+| `cargo "+nightly" run --example coex --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi,ble"`                            | ESP32-C3 |
+| `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`                                                           | ESP32    |
+| `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                                            | ESP32    |
+| `cargo "+esp" run --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                                       | ESP32    |
+| `cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"`                                                       | ESP32-S3 |
+| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`                                        | ESP32-S3 |
+| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`                                   | ESP32-S3 |
+| `cargo "+esp" run --example coex --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi,ble"`                                    | ESP32-S3 |
+| `CARGO_PROFILE_RELEASE_OPT_LEVEL=2 cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`      | ESP32-S2 |
+| `CARGO_PROFILE_RELEASE_OPT_LEVEL=2 cargo "+esp" run --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"` | ESP32-S2 |
+| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"`                                               | ESP32-C2 |
+| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`                                | ESP32-C2 |
+| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`                           | ESP32-C2 |
 
 Additionally you can specify these features
-|Feature|Meaning|
-|---|---|
-|wifi_logs|logs the WiFi logs from the driver at log level info|
-|dump_packets|dumps some packet info at log level info|
-|utils|Provide utilities for smoltcp initialization, this is a default feature|
-|embedded-svc|Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` feature|
-|ble|Enable BLE support|
-|wifi|Enable WiFi support|
+| Feature      | Meaning                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| wifi_logs    | logs the WiFi logs from the driver at log level info                                                |
+| dump_packets | dumps some packet info at log level info                                                            |
+| utils        | Provide utilities for smoltcp initialization, this is a default feature                             |
+| embedded-svc | Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` feature |
+| ble          | Enable BLE support                                                                                  |
+| wifi         | Enable WiFi support                                                                                 |
 
 ## Important
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ https://github.com/esp-rs/esp-wireless-drivers-3rdparty/ (commit f4caebff200e8f6
 
 If a cell contains am em dash (&mdash;) this means that the particular feature is not present for a chip. A check mark (✓) means that some driver implementation exists. An empty cell means that the feature is present in the chip but not implemented yet.
 
-|          | Wifi  |  BLE  |  Coex   |
-| :------: | :---: | :---: | :-----: |
-|  ESP32   |   ✓   |   ✓   |         |
-| ESP32-S2 |   ✓   |       | &mdash; |
-| ESP32-S3 |   ✓   |   ✓   |    ✓    |
-| ESP32-C3 |   ✓   |   ✓   |    ✓    |
-| ESP32-C2 |   ✓   |   ✓   |         |
+|          | [Wifi](https://github.com/esp-rs/esp-wifi/issues/94) | [BLE](https://github.com/esp-rs/esp-wifi/issues/93) | [Coex](https://github.com/esp-rs/esp-wifi/issues/92) |
+| :------: | :--------------------------------------------------: | :-------------------------------------------------: | :--------------------------------------------------: |
+|  ESP32   |                          ✓                           |                          ✓                          |                                                      |
+| ESP32-S2 |                          ✓                           |                       &mdash;                       |                       &mdash;                        |
+| ESP32-S3 |                          ✓                           |                          ✓                          |                          ✓                           |
+| ESP32-C3 |                          ✓                           |                          ✓                          |                          ✓                           |
+| ESP32-C2 |                          ✓                           |                          ✓                          |                                                      |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -50,31 +50,31 @@ If a cell contains am em dash (&mdash;) this means that the particular feature i
     - pressing the boot-button on a dev-board will send a notification if it is subscribed
     - this uses a toy level BLE stack - might not work with every BLE central device (tested with Android and Windows Bluetooth LE Explorer)
 
-- coex (ESP32-C3 only)
+- coex (ESP32-C3 and ESP32-S3 only)
   - set SSID and PASSWORD env variable
   - gets an ip address via DHCP
   - performs an HTTP get request to some "random" server
   - does BLE advertising
   - coex support is still somewhat flaky
 
-| Command                                                                                                                         | Chip    |
-| ------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c3,ble"`                    | ESP32-C3|
-| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`     | ESP32-C3|
-| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`| ESP32-C3|
-| `cargo "+nightly" run --example coex --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi,ble"` | ESP32-C3|
-| `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`                                | ESP32   |
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                 | ESP32   |
-| `cargo "+esp" run --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`            | ESP32   |
-| `cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"`                                | ESP32-S3 |
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`             | ESP32-S3|
-| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`        | ESP32-S3|
-| `cargo "+esp" run --example coex --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi,ble"`        | ESP32-S3|
-| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`             | ESP32-S2|
-| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`        | ESP32-S2|
-| `CARGO_PROFILE_RELEASE_LTO=false cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"`                    | ESP32-C2|
-| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`     | ESP32-C2|
-| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`| ESP32-C2|
+| Command                                                                                                                                      | Chip     |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c3,ble"`                                 | ESP32-C3 |
+| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`                  | ESP32-C3 |
+| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi"`             | ESP32-C3 |
+| `cargo "+nightly" run --example coex --release --target riscv32imc-unknown-none-elf --features "esp32c3,embedded-svc,wifi,ble"`              | ESP32-C3 |
+| `cargo "+esp" run --example ble --release --target xtensa-esp32-none-elf --features "esp32,ble"`                                             | ESP32    |
+| `cargo "+esp" run --example dhcp --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                              | ESP32    |
+| `cargo "+esp" run --example static_ip --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"`                         | ESP32    |
+| `cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"`                                         | ESP32-S3 |
+| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`                          | ESP32-S3 |
+| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"`                     | ESP32-S3 |
+| `cargo "+esp" run --example coex --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi,ble"`                      | ESP32-S3 |
+| `cargo "+esp" run --example dhcp --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`                          | ESP32-S2 |
+| `cargo "+esp" run --example static_ip --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"`                     | ESP32-S2 |
+| `CARGO_PROFILE_RELEASE_LTO=false cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"` | ESP32-C2 |
+| `cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`                  | ESP32-C2 |
+| `cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"`             | ESP32-C2 |
 
 Additionally you can specify these features
 | Feature      | Meaning                                                                                             |


### PR DESCRIPTION
- Add CI that checks
  - Examples
  - `build`
  - `fmt`
- Add a table with the current support of wifi/ble/coex in our devices 

Any feedback/suggestion is more than welcome. I'm also more than happy to discard this PR if you think it's not worth it.
Also [started cleaning some of the Clippy warnings](https://github.com/SergioGasquez/esp-wifi/pull/1/files)