### PR TITLE
Async WiFi: connect/disconnect/scan/wait_for_event

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -33,6 +33,7 @@ num-derive = { version = "0.3", features = ["full-syntax"] }
 num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { version = "0.1.0", optional = true }
+embassy-futures = { version = "0.1.0", optional = true }
 embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "26474ce6eb759e5add1c137f3417845e0797df3a", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 embassy-net-driver = { git = "https://github.com/embassy-rs/embassy", rev = "26474ce6eb759e5add1c137f3417845e0797df3a", optional = true }
 
@@ -81,7 +82,7 @@ esp32c2-async = [ "esp32c2-hal/embassy", "esp32c2-hal/embassy-time-timg0", "asyn
 esp32-async = [ "esp32-hal/embassy", "esp32-hal/embassy-time-timg0", "async" ]
 esp32s2-async = [ "esp32s2-hal/embassy", "esp32s2-hal/embassy-time-timg0", "async" ]
 esp32s3-async = [ "esp32s3-hal/embassy", "esp32s3-hal/embassy-time-timg0", "async" ]
-async = [ "dep:embassy-sync", "embedded-io/async"]
+async = [ "dep:embassy-sync", "dep:embassy-futures", "embedded-io/async"]
 embassy-net = ["dep:embassy-net", "dep:embassy-net-driver", "async"]
 
 # misc features

--- a/esp-wifi/examples/coex.rs
+++ b/esp-wifi/examples/coex.rs
@@ -72,7 +72,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&mut socket_set_entries);
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(feature = "esp32c3")]

--- a/esp-wifi/examples/coex.rs
+++ b/esp-wifi/examples/coex.rs
@@ -72,8 +72,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, sockets) = create_network_interface(&mut socket_set_entries);
-    let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(feature = "esp32c3")]
     {
@@ -88,32 +88,32 @@ fn main() -> ! {
         initialize(timg1.timer0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
 
-    println!("is wifi started: {:?}", wifi_stack.is_started());
+    let client_config = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASSWORD.into(),
+        ..Default::default()
+    });
+    let res = controller.set_configuration(&client_config);
+    println!("wifi_set_configuration returned {:?}", res);
+
+    controller.start().unwrap();
+    println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = wifi_stack.scan_n();
+    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = controller.scan_n();
     if let Ok((res, _count)) = res {
         for ap in res {
             println!("{:?}", ap);
         }
     }
 
-    println!("Call wifi_connect");
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
-    });
-    let res = wifi_stack.set_configuration(&client_config);
-    println!("wifi_connect returned {:?}", res);
-
-    println!("{:?}", wifi_stack.get_capabilities());
-    println!("wifi_connect {:?}", wifi_stack.connect());
+    println!("{:?}", controller.get_capabilities());
+    println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected
     println!("Wait to get connected");
     loop {
-        let res = wifi_stack.is_connected();
+        let res = controller.is_connected();
         match res {
             Ok(connected) => {
                 if connected {
@@ -126,7 +126,7 @@ fn main() -> ! {
             }
         }
     }
-    println!("{:?}", wifi_stack.is_connected());
+    println!("{:?}", controller.is_connected());
 
     // wait for getting an ip address
     println!("Wait to get an ip address");

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -86,7 +86,6 @@ fn main() -> ! {
         initialize(timg1.timer0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
 
-    println!("Call wifi_connect");
     let client_config = Configuration::Client(ClientConfiguration {
         ssid: SSID.into(),
         password: PASSWORD.into(),

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -70,8 +70,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, sockets) = create_network_interface(&mut socket_set_entries);
-    let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
     {
@@ -92,27 +92,27 @@ fn main() -> ! {
         password: PASSWORD.into(),
         ..Default::default()
     });
-    let res = wifi_stack.set_configuration(&client_config);
+    let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);
 
-    wifi_stack.start().unwrap();
-    println!("is wifi started: {:?}", wifi_stack.is_started());
+    controller.start().unwrap();
+    println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = wifi_stack.scan_n();
+    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = controller.scan_n();
     if let Ok((res, _count)) = res {
         for ap in res {
             println!("{:?}", ap);
         }
     }
 
-    println!("{:?}", wifi_stack.get_capabilities());
-    println!("wifi_connect {:?}", wifi_stack.connect());
+    println!("{:?}", controller.get_capabilities());
+    println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected
     println!("Wait to get connected");
     loop {
-        let res = wifi_stack.is_connected();
+        let res = controller.is_connected();
         match res {
             Ok(connected) => {
                 if connected {
@@ -125,7 +125,7 @@ fn main() -> ! {
             }
         }
     }
-    println!("{:?}", wifi_stack.is_connected());
+    println!("{:?}", controller.is_connected());
 
     // wait for getting an ip address
     println!("Wait to get an ip address");

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -70,7 +70,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&mut socket_set_entries);
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -86,6 +86,16 @@ fn main() -> ! {
         initialize(timg1.timer0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
 
+    println!("Call wifi_connect");
+    let client_config = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASSWORD.into(),
+        ..Default::default()
+    });
+    let res = wifi_stack.set_configuration(&client_config);
+    println!("wifi_set_configuration returned {:?}", res);
+
+    wifi_stack.start().unwrap();
     println!("is wifi started: {:?}", wifi_stack.is_started());
 
     println!("Start Wifi Scan");
@@ -95,15 +105,6 @@ fn main() -> ! {
             println!("{:?}", ap);
         }
     }
-
-    println!("Call wifi_connect");
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
-    });
-    let res = wifi_stack.set_configuration(&client_config);
-    println!("wifi_set_configuration returned {:?}", res);
 
     println!("{:?}", wifi_stack.get_capabilities());
     println!("wifi_connect {:?}", wifi_stack.connect());

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -97,123 +97,153 @@ fn main() -> ! {
     println!("is wifi started: {:?}", wifi_interface.is_started());
 
     println!("Start Wifi Scan");
-    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> =
-        wifi_interface.scan_n();
-    if let Ok((res, _count)) = res {
-        for ap in res {
-            println!("{:?}", ap);
-        }
-    }
+    // let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> =
+    //     wifi_interface.scan_n();
+    // if let Ok((res, _count)) = res {
+    //     for ap in res {
+    //         println!("{:?}", ap);
+    //     }
+    // }
+    
 
-    println!("Call wifi_connect");
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
-    });
-    let res = wifi_interface.set_configuration(&client_config);
-    println!("wifi_set_configuration returned {:?}", res);
+    // println!("Call wifi_connect");
+    // let client_config = Configuration::Client(ClientConfiguration {
+    //     ssid: SSID.into(),
+    //     password: PASSWORD.into(),
+    //     ..Default::default()
+    // });
+    // let res = wifi_interface.set_configuration(&client_config);
+    // println!("wifi_set_configuration returned {:?}", res);
 
-    println!("{:?}", wifi_interface.get_capabilities());
-    println!("wifi_connect {:?}", wifi_interface.connect());
+    // println!("{:?}", wifi_interface.get_capabilities());
+    // println!("wifi_connect {:?}", wifi_interface.connect());
 
-    // wait to get connected
-    println!("Wait to get connected");
-    loop {
-        let res = wifi_interface.is_connected();
-        match res {
-            Ok(connected) => {
-                if connected {
-                    break;
-                }
-            }
-            Err(err) => {
-                println!("{:?}", err);
-                loop {}
-            }
-        }
-    }
-    println!("{:?}", wifi_interface.is_connected());
+    // // wait to get connected
+    // println!("Wait to get connected");
+    // loop {
+    //     let res = wifi_interface.is_connected();
+    //     match res {
+    //         Ok(connected) => {
+    //             if connected {
+    //                 break;
+    //             }
+    //         }
+    //         Err(err) => {
+    //             println!("{:?}", err);
+    //             loop {}
+    //         }
+    //     }
+    // }
+    // println!("{:?}", wifi_interface.is_connected());
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    // let config = Config::Dhcp(Default::default());
 
-    let seed = 1234; // very random, very secure seed
+    // let seed = 1234; // very random, very secure seed
 
-    // Init network stack
-    let stack = &*singleton!(Stack::new(
-        wifi_interface,
-        config,
-        singleton!(StackResources::<3>::new()),
-        seed
-    ));
+    // // Init network stack
+    // let stack = &*singleton!(Stack::new(
+    //     wifi_interface,
+    //     config,
+    //     singleton!(StackResources::<3>::new()),
+    //     seed
+    // ));
 
     let executor = EXECUTOR.init(Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(net_task(&stack)).ok();
-        spawner.spawn(task(&stack)).ok();
+        // spawner.spawn(net_task(&stack)).ok();
+        // spawner.spawn(task(&stack)).ok();
+        spawner.spawn(pinger()).ok();
+        spawner.spawn(scanner(wifi_interface)).ok();
     });
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice>) {
-    stack.run().await
+async fn scanner(mut wifi_interface: WifiDevice) {
+    loop {
+        println!("Begin scan...");
+        let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> =
+            wifi_interface.scan_n_async().await;
+        match res {
+            Ok((res, n)) => {
+                println!("Scan returned {} results, ", n);
+                for ap in res {
+                    println!("{:?}", ap);
+                }
+            },
+            Err(e) => println!("Scan error: {:?}", e)
+        }
+        Timer::after(Duration::from_millis(3000)).await;
+    }
 }
 
 #[embassy_executor::task]
-async fn task(stack: &'static Stack<WifiDevice>) {
-    let mut rx_buffer = [0; 4096];
-    let mut tx_buffer = [0; 4096];
-
-    println!("Waiting to get IP address...");
+async fn pinger() {
     loop {
-        if let Some(config) = stack.config() {
-            println!("Got IP: {}", config.address);
-            break;
-        }
-        Timer::after(Duration::from_millis(500)).await;
-    }
-
-    loop {
-        Timer::after(Duration::from_millis(1_000)).await;
-
-        let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
-
-        let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
-        println!("connecting...");
-        let r = socket.connect(remote_endpoint).await;
-        if let Err(e) = r {
-            println!("connect error: {:?}", e);
-            continue;
-        }
-        println!("connected!");
-        let mut buf = [0; 1024];
-        loop {
-            use embedded_io::asynch::Write;
-            let r = socket
-                .write_all(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
-                .await;
-            if let Err(e) = r {
-                println!("write error: {:?}", e);
-                break;
-            }
-            let n = match socket.read(&mut buf).await {
-                Ok(0) => {
-                    println!("read EOF");
-                    break;
-                }
-                Ok(n) => n,
-                Err(e) => {
-                    println!("read error: {:?}", e);
-                    break;
-                }
-            };
-            println!("{}", core::str::from_utf8(&buf[..n]).unwrap());
-        }
+        println!("Ping!");
         Timer::after(Duration::from_millis(1000)).await;
     }
 }
+
+// #[embassy_executor::task]
+// async fn net_task(stack: &'static Stack<WifiDevice>) {
+//     stack.run().await
+// }
+
+// #[embassy_executor::task]
+// async fn task(stack: &'static Stack<WifiDevice>) {
+//     let mut rx_buffer = [0; 4096];
+//     let mut tx_buffer = [0; 4096];
+
+//     println!("Waiting to get IP address...");
+//     loop {
+//         if let Some(config) = stack.config() {
+//             println!("Got IP: {}", config.address);
+//             break;
+//         }
+//         Timer::after(Duration::from_millis(500)).await;
+//     }
+
+//     loop {
+//         Timer::after(Duration::from_millis(1_000)).await;
+
+//         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
+
+//         socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+
+//         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
+//         println!("connecting...");
+//         let r = socket.connect(remote_endpoint).await;
+//         if let Err(e) = r {
+//             println!("connect error: {:?}", e);
+//             continue;
+//         }
+//         println!("connected!");
+//         let mut buf = [0; 1024];
+//         loop {
+//             use embedded_io::asynch::Write;
+//             let r = socket
+//                 .write_all(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
+//                 .await;
+//             if let Err(e) = r {
+//                 println!("write error: {:?}", e);
+//                 break;
+//             }
+//             let n = match socket.read(&mut buf).await {
+//                 Ok(0) => {
+//                     println!("read EOF");
+//                     break;
+//                 }
+//                 Ok(n) => n,
+//                 Err(e) => {
+//                     println!("read error: {:?}", e);
+//                     break;
+//                 }
+//             };
+//             println!("{}", core::str::from_utf8(&buf[..n]).unwrap());
+//         }
+//         Timer::after(Duration::from_millis(1000)).await;
+//     }
+// }

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -165,7 +165,7 @@ async fn scanner(mut wifi_interface: WifiDevice) {
     loop {
         println!("Begin scan...");
         let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> =
-            wifi_interface.scan_n_async().await;
+            wifi_interface.scan_n().await;
         match res {
             Ok((res, n)) => {
                 println!("Scan returned {} results, ", n);

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -125,8 +125,7 @@ async fn connection(mut controller: WifiController) {
         match esp_wifi::wifi::get_wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
-                // TODO this is probably bad design, two calls too the same event will result in the the first being overwritten by the second call
-                WifiEvent::StaDisconnected.await;
+                controller.wait_for_event(WifiEvent::StaDisconnected).await;
                 Timer::after(Duration::from_millis(5000)).await
             },
             _ => {}

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -126,6 +126,7 @@ async fn connection(_stack: &'static Stack<WifiDevice>) {
         match esp_wifi::wifi::get_wifi_state() {
             WifiState::StaConnected => {
                 // wait until we're no longer connected
+                // TODO this is probably bad design, two calls too the same event will result in the the first being overwritten by the second call
                 WifiEvent::StaDisconnected.await;
                 Timer::after(Duration::from_millis(5000)).await
             },

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -25,7 +25,7 @@ use esp_backtrace as _;
 use esp_println::logger::init_logger;
 use esp_println::println;
 use esp_wifi::initialize;
-use esp_wifi::wifi::{WifiDevice, WifiState, WifiEvent, WifiController};
+use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiState};
 use hal::clock::{ClockControl, CpuClock};
 use hal::Rng;
 use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
@@ -127,7 +127,7 @@ async fn connection(mut controller: WifiController) {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::StaDisconnected).await;
                 Timer::after(Duration::from_millis(5000)).await
-            },
+            }
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
@@ -142,13 +142,13 @@ async fn connection(mut controller: WifiController) {
             println!("Wifi started!");
         }
         println!("About to connect...");
-        
+
         match controller.connect().await {
             Ok(_) => println!("Wifi connected!"),
-            Err(e) => { 
+            Err(e) => {
                 println!("Failed to connect to wifi: {e:?}");
                 Timer::after(Duration::from_millis(5000)).await
-            },
+            }
         }
     }
 }

--- a/esp-wifi/examples/static_ip.rs
+++ b/esp-wifi/examples/static_ip.rs
@@ -71,7 +71,7 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, sockets) = create_network_interface(&mut socket_set_entries);
+    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
@@ -87,32 +87,32 @@ fn main() -> ! {
         initialize(timg1.timer0, Rng::new(peripherals.RNG), &clocks).unwrap();
     }
 
-    println!("is wifi started: {:?}", wifi_stack.is_started());
+    let client_config = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASSWORD.into(),
+        ..Default::default()
+    });
+    let res = controller.set_configuration(&client_config);
+    println!("wifi_set_configuration returned {:?}", res);
+
+    controller.start().unwrap();
+    println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = wifi_stack.scan_n();
+    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = controller.scan_n();
     if let Ok((res, _count)) = res {
         for ap in res {
             println!("{:?}", ap);
         }
     }
 
-    println!("Call wifi_connect");
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
-    });
-    let res = wifi_stack.set_configuration(&client_config);
-    println!("wifi_set_configuration returned {:?}", res);
-
-    println!("{:?}", wifi_stack.get_capabilities());
-    println!("wifi_connect {:?}", wifi_stack.connect());
+    println!("{:?}", controller.get_capabilities());
+    println!("wifi_connect {:?}", controller.connect());
 
     // wait to get connected
     println!("Wait to get connected");
     loop {
-        let res = wifi_stack.is_connected();
+        let res = controller.is_connected();
         match res {
             Ok(connected) => {
                 if connected {
@@ -125,7 +125,7 @@ fn main() -> ! {
             }
         }
     }
-    println!("{:?}", wifi_stack.is_connected());
+    println!("{:?}", controller.is_connected());
 
     println!("Setting static IP {}", STATIC_IP);
 

--- a/esp-wifi/examples/static_ip.rs
+++ b/esp-wifi/examples/static_ip.rs
@@ -71,7 +71,8 @@ fn main() -> ! {
     rtc.rwdt.disable();
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) = create_network_interface(&mut socket_set_entries);
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&mut socket_set_entries);
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -221,6 +221,8 @@ impl EspNowCreator {
     /// After this the broadcast address is already added as a peer.
     pub fn initialize(self) -> Result<EspNow, EspNowError> {
         let mut esp_now = EspNow { _private: () };
+        check_error!({ esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_STA) });
+        check_error!({ esp_wifi_start() });
         check_error!({ esp_now_init() });
         check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) });
 

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -73,7 +73,7 @@ pub(crate) mod memory_fence;
 pub use critical_section;
 use timer::{get_systimer_count, TICKS_PER_SECOND};
 
-#[cfg(all(feature = "embedded-svc", feature = "wifi", not(feature = "embassy-net")))]
+#[cfg(all(feature = "embedded-svc", feature = "wifi"))]
 pub mod wifi_interface;
 
 #[cfg(feature = "esp32c3")]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -143,7 +143,6 @@ pub fn initialize(
         log::debug!("wifi init");
         // wifi init
         crate::wifi::wifi_init()?;
-        crate::wifi::wifi_start()?;
     }
 
     #[cfg(feature = "ble")]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -73,7 +73,7 @@ pub(crate) mod memory_fence;
 pub use critical_section;
 use timer::{get_systimer_count, TICKS_PER_SECOND};
 
-#[cfg(all(feature = "embedded-svc", feature = "wifi"))]
+#[cfg(all(feature = "embedded-svc", feature = "wifi", not(feature = "embassy-net")))]
 pub mod wifi_interface;
 
 #[cfg(feature = "esp32c3")]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -216,7 +216,6 @@ pub fn initialize(
     {
         log::debug!("wifi init");
         crate::wifi::wifi_init()?;
-        crate::wifi::wifi_start()?;
     }
 
     #[cfg(feature = "ble")]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -87,7 +87,7 @@ pub fn current_millis() -> u64 {
 }
 
 #[cfg(not(coex))]
-const HEAP_SIZE: usize = 42 * 1024;
+const HEAP_SIZE: usize = 64 * 1024;
 
 #[cfg(coex)]
 const HEAP_SIZE: usize = 64 * 1024;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1219,17 +1219,17 @@ mod asynch {
 
     // TODO assumes STA mode only
     impl WifiController {
+        /// Async version of [`embedded_svc::wifi::Wifi`]'s `scan_n` method
         pub async fn scan_n<const N: usize>(
             &mut self,
         ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), WifiError> {
             critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove(WifiEvent::ScanDone));
             esp_wifi_result!(crate::wifi::wifi_start_scan(false))?;
-
             WifiEventFuture::new(WifiEvent::ScanDone).await;
-
             self.scan_results()
         }
 
+        /// Async version of [`embedded_svc::wifi::Wifi`]'s `start` method
         pub async fn start(&mut self) -> Result<(), WifiError> {
             critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove(WifiEvent::StaStart));
             wifi_start()?;
@@ -1237,6 +1237,7 @@ mod asynch {
             Ok(())
         }
 
+        /// Async version of [`embedded_svc::wifi::Wifi`]'s `stop` method
         pub async fn stop(&mut self) -> Result<(), WifiError> {
             critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove(WifiEvent::StaStop));
             embedded_svc::wifi::Wifi::stop(self)?;
@@ -1244,6 +1245,7 @@ mod asynch {
             Ok(())
         }
 
+        /// Async version of [`embedded_svc::wifi::Wifi`]'s `connect` method
         pub async fn connect(&mut self) -> Result<(), WifiError> {
             critical_section::with(|cs| {
                 WIFI_EVENTS
@@ -1264,6 +1266,7 @@ mod asynch {
             }
         }
 
+        /// Async version of [`embedded_svc::wifi::Wifi`]'s `Disconnect` method
         pub async fn disconnect(&mut self) -> Result<(), WifiError> {
             critical_section::with(|cs| {
                 WIFI_EVENTS
@@ -1275,6 +1278,7 @@ mod asynch {
             Ok(())
         }
 
+        /// Wait for a [`WifiEvent`].
         pub async fn wait_for_event(&mut self, event: WifiEvent) {
             critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove(event));
             WifiEventFuture::new(event).await;
@@ -1282,8 +1286,8 @@ mod asynch {
     }
 
     impl WifiEvent {
-        pub(crate) fn waker(&self) -> Option<&'static AtomicWaker> {
-            Some(match self {
+        pub(crate) fn waker(&self) -> &'static AtomicWaker {
+            match self {
                 WifiEvent::ScanDone => {
                     static WAKER: AtomicWaker = AtomicWaker::new();
                     &WAKER
@@ -1304,28 +1308,79 @@ mod asynch {
                     static WAKER: AtomicWaker = AtomicWaker::new();
                     &WAKER
                 }
-                WifiEvent::WifiReady
-                | WifiEvent::StaAuthmodeChange
-                | WifiEvent::StaWpsErSuccess
-                | WifiEvent::StaWpsErFailed
-                | WifiEvent::StaWpsErTimeout
-                | WifiEvent::StaWpsErPin
-                | WifiEvent::StaWpsErPbcOverlap
-                | WifiEvent::ApStart
-                | WifiEvent::ApStop
-                | WifiEvent::ApStaconnected
-                | WifiEvent::ApStadisconnected
-                | WifiEvent::ApProbereqrecved
-                | WifiEvent::FtmReport
-                | WifiEvent::StaBssRssiLow
-                | WifiEvent::ActionTxStatus
-                | WifiEvent::RocDone
-                | WifiEvent::StaBeaconTimeout => return None,
-            })
+                WifiEvent::WifiReady => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaAuthmodeChange => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaWpsErSuccess => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaWpsErFailed => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaWpsErTimeout => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaWpsErPin => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaWpsErPbcOverlap => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ApStart => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ApStop => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ApStaconnected => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ApStadisconnected => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ApProbereqrecved => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::FtmReport => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaBssRssiLow => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::ActionTxStatus => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::RocDone => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+                WifiEvent::StaBeaconTimeout => {
+                    static WAKER: AtomicWaker = AtomicWaker::new();
+                    &WAKER
+                }
+            }
         }
     }
 
-    pub struct WifiEventFuture {
+    pub(crate) struct WifiEventFuture {
         event: WifiEvent,
     }
 
@@ -1342,10 +1397,7 @@ mod asynch {
             self: core::pin::Pin<&mut Self>,
             cx: &mut core::task::Context<'_>,
         ) -> Poll<Self::Output> {
-            self.event
-                .waker()
-                .expect("Not yet implemented, unable to await this event")
-                .register(cx.waker());
+            self.event.waker().register(cx.waker());
             if critical_section::with(|cs| WIFI_EVENTS.borrow_ref(cs).contains(self.event)) {
                 Poll::Ready(())
             } else {

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -633,14 +633,12 @@ pub fn new() -> (WifiDevice, WifiController) {
 
 /// A wifi device implementing smoltcp's Device trait.
 pub struct WifiDevice {
-    _private: ()
+    _private: (),
 }
 
 impl WifiDevice {
     pub(crate) fn new() -> WifiDevice {
-        Self {
-            _private: ()
-        }
+        Self { _private: () }
     }
 }
 
@@ -650,13 +648,14 @@ pub struct WifiController {
 }
 
 impl WifiController {
-
     pub(crate) fn new_with_config(config: embedded_svc::wifi::Configuration) -> Self {
         Self { config }
     }
 
     pub(crate) fn new() -> Self {
-        Self { config: Default::default() }
+        Self {
+            config: Default::default(),
+        }
     }
 
     fn is_sta_enabled(&self) -> Result<bool, WifiError> {
@@ -892,7 +891,6 @@ pub fn send_data_if_needed() {
             #[cfg(feature = "embassy-net")]
             embassy::TRANSMIT_WAKER.wake();
         }
-
     });
 }
 
@@ -962,9 +960,7 @@ impl embedded_svc::wifi::Wifi for WifiController {
                                 AuthMethod::WPA2Enterprise => {
                                     wifi_auth_mode_t_WIFI_AUTH_WPA2_ENTERPRISE
                                 }
-                                AuthMethod::WPA3Personal => {
-                                    wifi_auth_mode_t_WIFI_AUTH_WPA3_PSK
-                                },
+                                AuthMethod::WPA3Personal => wifi_auth_mode_t_WIFI_AUTH_WPA3_PSK,
                                 AuthMethod::WPA2WPA3Personal => {
                                     wifi_auth_mode_t_WIFI_AUTH_WPA2_WPA3_PSK
                                 }
@@ -987,7 +983,8 @@ impl embedded_svc::wifi::Wifi for WifiController {
 
                 unsafe {
                     cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
-                    cfg.sta.password[0..(config.password.len())].copy_from_slice(config.password.as_bytes());
+                    cfg.sta.password[0..(config.password.len())]
+                        .copy_from_slice(config.password.as_bytes());
                 }
                 esp_wifi_result!(unsafe {
                     esp_wifi_set_config(wifi_interface_t_WIFI_IF_STA, &mut cfg)
@@ -1248,7 +1245,11 @@ mod asynch {
         }
 
         pub async fn connect(&mut self) -> Result<(), WifiError> {
-            critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove_all(WifiEvent::StaConnected | WifiEvent::StaDisconnected));
+            critical_section::with(|cs| {
+                WIFI_EVENTS
+                    .borrow_ref_mut(cs)
+                    .remove_all(WifiEvent::StaConnected | WifiEvent::StaDisconnected)
+            });
             let err = embedded_svc::wifi::Wifi::connect(self).err();
             match embassy_futures::select::select(
                 WifiEventFuture::new(WifiEvent::StaConnected),
@@ -1257,12 +1258,18 @@ mod asynch {
             .await
             {
                 embassy_futures::select::Either::First(_) => Ok(()),
-                embassy_futures::select::Either::Second(_) => Err(err.unwrap_or(WifiError::Disconnected)),
+                embassy_futures::select::Either::Second(_) => {
+                    Err(err.unwrap_or(WifiError::Disconnected))
+                }
             }
         }
 
         pub async fn disconnect(&mut self) -> Result<(), WifiError> {
-            critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).remove(WifiEvent::StaDisconnected));
+            critical_section::with(|cs| {
+                WIFI_EVENTS
+                    .borrow_ref_mut(cs)
+                    .remove(WifiEvent::StaDisconnected)
+            });
             embedded_svc::wifi::Wifi::disconnect(self)?;
             WifiEventFuture::new(WifiEvent::StaDisconnected).await;
             Ok(())
@@ -1324,9 +1331,7 @@ mod asynch {
 
     impl WifiEventFuture {
         pub fn new(event: WifiEvent) -> Self {
-            Self {
-                event,
-            }
+            Self { event }
         }
     }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1208,7 +1208,13 @@ mod asynch {
         }
 
         pub async fn start(&mut self) -> Result<(), WifiError> {
-            wifi_start()?; // starts immediately - non blocking?
+            use embedded_svc::wifi::Wifi;
+
+            wifi_start()?;
+            // if start doesn't start immediatly, wait for event
+            if !matches!(self.is_started(), Ok(true)) {
+                WifiEvent::StaStart.await;
+            }
             Ok(())
         }
 
@@ -1232,7 +1238,9 @@ mod asynch {
         }
 
         pub async fn disconnect(&mut self) -> Result<(), WifiError> {
-            todo!()
+            embedded_svc::wifi::Wifi::disconnect(self)?;
+            WifiEventFuture::new(WifiEvent::StaDisconnected).await;
+            Ok(())
         }
     }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -868,10 +868,10 @@ pub fn send_data_if_needed() {
                 }
                 log::trace!("esp_wifi_internal_tx {}", _res);
             }
+            #[cfg(feature = "embassy-net")]
+            embassy::TRANSMIT_WAKER.wake();
         }
 
-        #[cfg(feature = "embassy-net")]
-        embassy::TRANSMIT_WAKER.wake();
     });
 }
 

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -929,7 +929,7 @@ pub unsafe extern "C" fn event_post(
     }
 
     #[cfg(feature = "async")]
-    event.waker().map(|w| w.wake());
+    event.waker().wake();
 
     #[cfg(feature = "embassy-net")]
     if matches!(event, WifiEvent::StaConnected | WifiEvent::StaDisconnected) {

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -918,7 +918,7 @@ pub unsafe extern "C" fn event_post(
     }
 
     #[cfg(feature = "async")]
-    crate::wifi::asynch::WIFI_EVENT_WAKER.wake();
+    event.waker().map(|w| w.wake());
 
     memory_fence();
 

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -900,9 +900,11 @@ pub unsafe extern "C" fn event_post(
     use num_traits::FromPrimitive;
 
     let event = WifiEvent::from_i32(event_id).unwrap();
+    log::info!("EVENT: {:?}", event);
 
     let take_state = match event {
         WifiEvent::StaConnected
+        | WifiEvent::StaDisconnected
         | WifiEvent::StaStart
         | WifiEvent::StaStop
         | WifiEvent::WifiReady

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -30,9 +30,9 @@ use crate::compat::common::syslog;
 
 use super::WifiEvent;
 
-pub static mut WIFI_STATE: i32 = -1;
+pub(crate) static mut WIFI_STATE: i32 = -1;
 
-pub static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
+pub(crate) static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
     Mutex::new(RefCell::new(enumset::enum_set!()));
 
 pub fn is_connected() -> bool {

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -32,6 +32,7 @@ use super::WifiEvent;
 
 pub(crate) static mut WIFI_STATE: i32 = -1;
 
+// useful for waiting for events - clear and wait for the event bit to be set again
 pub(crate) static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
     Mutex::new(RefCell::new(enumset::enum_set!()));
 

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -922,6 +922,12 @@ pub unsafe extern "C" fn event_post(
     #[cfg(feature = "async")]
     event.waker().map(|w| w.wake());
 
+    #[cfg(feature = "embassy-net")]
+    if matches!(event, WifiEvent::StaConnected | WifiEvent::StaDisconnected) {
+        log::info!("Waking LINK_STATE");
+        crate::wifi::embassy::LINK_STATE.wake();
+    }
+
     memory_fence();
 
     0

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -900,7 +900,7 @@ pub unsafe extern "C" fn event_post(
     use num_traits::FromPrimitive;
 
     let event = WifiEvent::from_i32(event_id).unwrap();
-    log::info!("EVENT: {:?}", event);
+    log::trace!("EVENT: {:?}", event);
 
     let take_state = match event {
         WifiEvent::StaConnected

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -32,7 +32,8 @@ use super::WifiEvent;
 
 pub static mut WIFI_STATE: i32 = -1;
 
-pub static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> = Mutex::new(RefCell::new(enumset::enum_set!()));
+pub static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
+    Mutex::new(RefCell::new(enumset::enum_set!()));
 
 pub fn is_connected() -> bool {
     unsafe { WIFI_STATE == wifi_event_t_WIFI_EVENT_STA_CONNECTED as i32 }

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -7,20 +7,20 @@ use smoltcp::{
 
 use crate::wifi::get_sta_mac;
 
-use super::WifiDevice;
+use super::{WifiDevice, WifiController};
 
 /// Convenient way to create an `smoltcp` ethernet interface
 /// You can use the provided macros to create and pass a suitable backing storage.
 pub fn create_network_interface<'a>(
     storage: &'a mut [SocketStorage<'a>],
-) -> (Interface, WifiDevice, SocketSet<'a>) {
+) -> (Interface, WifiDevice, WifiController, SocketSet<'a>) {
     let socket_set_entries = storage;
 
     let mut mac = [0u8; 6];
     get_sta_mac(&mut mac);
     let hw_address = EthernetAddress::from_bytes(&mac);
 
-    let mut device = WifiDevice::new();
+    let (mut device, controller) = crate::wifi::new();
 
     let mut config = Config::new();
 
@@ -35,5 +35,5 @@ pub fn create_network_interface<'a>(
     let dhcp_socket = Dhcpv4Socket::new();
     socket_set.add(dhcp_socket);
 
-    (iface, device, socket_set)
+    (iface, device, controller, socket_set)
 }

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -7,7 +7,7 @@ use smoltcp::{
 
 use crate::wifi::get_sta_mac;
 
-use super::{WifiDevice, WifiController};
+use super::{WifiController, WifiDevice};
 
 /// Convenient way to create an `smoltcp` ethernet interface
 /// You can use the provided macros to create and pass a suitable backing storage.

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -4,8 +4,6 @@ use embedded_io::blocking::{Read, Write};
 use embedded_io::Io;
 
 use embedded_svc::ipv4;
-use embedded_svc::wifi::AccessPointInfo;
-use enumset::EnumSet;
 use smoltcp::iface::{Interface, SocketHandle, SocketSet};
 use smoltcp::socket::{dhcpv4::Socket as Dhcpv4Socket, tcp::Socket as TcpSocket};
 use smoltcp::storage::PacketMetadata;
@@ -226,55 +224,6 @@ pub enum WifiStackError {
 impl Display for WifiStackError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
-    }
-}
-
-impl embedded_svc::wifi::Wifi for WifiStack<'_> {
-    type Error = crate::wifi::WifiError;
-
-    fn get_capabilities(&self) -> Result<EnumSet<embedded_svc::wifi::Capability>, Self::Error> {
-        self.device.borrow_mut().get_capabilities()
-    }
-
-    fn get_configuration(&self) -> Result<embedded_svc::wifi::Configuration, Self::Error> {
-        self.device.borrow_mut().get_configuration()
-    }
-
-    fn set_configuration(
-        &mut self,
-        conf: &embedded_svc::wifi::Configuration,
-    ) -> Result<(), Self::Error> {
-        self.device.borrow_mut().set_configuration(conf)
-    }
-
-    fn start(&mut self) -> Result<(), Self::Error> {
-        self.device.borrow_mut().start()
-    }
-
-    fn stop(&mut self) -> Result<(), Self::Error> {
-        self.device.borrow_mut().stop()
-    }
-
-    fn connect(&mut self) -> Result<(), Self::Error> {
-        self.device.borrow_mut().connect()
-    }
-
-    fn disconnect(&mut self) -> Result<(), Self::Error> {
-        self.device.borrow_mut().disconnect()
-    }
-
-    fn is_started(&self) -> Result<bool, Self::Error> {
-        self.device.borrow_mut().is_started()
-    }
-
-    fn is_connected(&self) -> Result<bool, Self::Error> {
-        self.device.borrow_mut().is_connected()
-    }
-
-    fn scan_n<const N: usize>(
-        &mut self,
-    ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error> {
-        self.device.borrow_mut().scan_n::<N>()
     }
 }
 


### PR DESCRIPTION
First off, I'm sorry. This PR got a bit out of hand scope-wise and ends up doing a few things, hopefully reviewing it isn't too much of a pain!

This PR accomplishes the following:

- Adds and implements async variants of the `embedded::wifi::Wifi` trait
- Plus one more, `wait_for_event` to asynchronously  wait for any Wifi related events
- splits wifi into two parts, device and controller
  - where device is the thing passed into stacks for packet send/recv
  - where controller handles the link/connection
- Closes #120 
- Closes #126 
- Moves the transmit waker _inside_ the check as to whether we actually sent the packet! This didn't break anything but was less efficient
  - This can actually be improved even further later on down the line, see https://github.com/embassy-rs/embassy/issues/1212#issuecomment-1427150821
- Clears scan memory on failure to avoid memory leaks