### PR TITLE
Check embassy examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32-none-elf --features=esp32,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32-none-elf --features=esp32,embedded-svc,wifi
+      - name: build (embassy_esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32-none-elf --features=esp32,esp32-async,esp-now
+      - name: build (embassy_dhcp)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_dhcp --target=xtensa-esp32-none-elf --features=esp32,esp32-async,embedded-svc,wifi,embassy-net
 
   esp32c2:
     runs-on: ubuntu-latest
@@ -59,6 +63,10 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=riscv32imc-unknown-none-elf --features=esp32c2,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=riscv32imc-unknown-none-elf --features=esp32c2,embedded-svc,wifi
+      - name: build (embassy_esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=riscv32imc-unknown-none-elf --features=esp32c2,esp32c2-async,esp-now
+      - name: build (embassy_dhcp)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_dhcp --target=riscv32imc-unknown-none-elf --features=esp32c2,esp32c2-async,embedded-svc,wifi,embassy-net
 
   esp32c3:
     runs-on: ubuntu-latest
@@ -78,6 +86,10 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=riscv32imc-unknown-none-elf --features=esp32c3,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=riscv32imc-unknown-none-elf --features=esp32c3,embedded-svc,wifi
+      - name: build (embassy_esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=riscv32imc-unknown-none-elf --features=esp32c3,esp32c3-async,esp-now
+      - name: build (embassy_dhcp)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_dhcp --target=riscv32imc-unknown-none-elf --features=esp32c3,esp32c3-async,embedded-svc,wifi,embassy-net
 
   esp32s2:
     runs-on: ubuntu-latest
@@ -94,6 +106,10 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32s2-none-elf --features=esp32s2,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32s2-none-elf --features=esp32s2,embedded-svc,wifi
+      - name: build (embassy_esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32s2-none-elf --features=esp32s2,esp32s2-async,esp-now
+      - name: build (embassy_dhcp)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_dhcp --target=xtensa-esp32s2-none-elf --features=esp32s2,esp32s2-async,embedded-svc,wifi,embassy-net
 
   esp32s3:
     runs-on: ubuntu-latest
@@ -114,3 +130,7 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32s3-none-elf --features=esp32s3,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32s3-none-elf --features=esp32s3,embedded-svc,wifi
+      - name: build (embassy_esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32s3-none-elf --features=esp32s3,esp32s3-async,esp-now
+      - name: build (embassy_dhcp)
+        run: cd esp-wifi/ && cargo build --release --example=embassy_dhcp --target=xtensa-esp32s3-none-elf --features=esp32s3,esp32s3-async,embedded-svc,wifi,embassy-net

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32-none-elf --features=esp32,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32-none-elf --features=esp32,embedded-svc,wifi
+      - name: build (esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=esp_now --target=xtensa-esp32-none-elf --features=esp32,esp-now
       - name: build (embassy_esp_now)
         run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32-none-elf --features=esp32,esp32-async,esp-now
       - name: build (embassy_dhcp)
@@ -63,6 +65,8 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=riscv32imc-unknown-none-elf --features=esp32c2,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=riscv32imc-unknown-none-elf --features=esp32c2,embedded-svc,wifi
+      - name: build (esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=esp_now --target=riscv32imc-unknown-none-elf --features=esp32c2,esp-now
       - name: build (embassy_esp_now)
         run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=riscv32imc-unknown-none-elf --features=esp32c2,esp32c2-async,esp-now
       - name: build (embassy_dhcp)
@@ -86,6 +90,8 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=riscv32imc-unknown-none-elf --features=esp32c3,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=riscv32imc-unknown-none-elf --features=esp32c3,embedded-svc,wifi
+      - name: build (esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=esp_now --target=riscv32imc-unknown-none-elf --features=esp32c3,esp-now
       - name: build (embassy_esp_now)
         run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=riscv32imc-unknown-none-elf --features=esp32c3,esp32c3-async,esp-now
       - name: build (embassy_dhcp)
@@ -106,6 +112,8 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32s2-none-elf --features=esp32s2,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32s2-none-elf --features=esp32s2,embedded-svc,wifi
+      - name: build (esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=esp_now --target=xtensa-esp32s2-none-elf --features=esp32s2,esp-now
       - name: build (embassy_esp_now)
         run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32s2-none-elf --features=esp32s2,esp32s2-async,esp-now
       - name: build (embassy_dhcp)
@@ -130,6 +138,8 @@ jobs:
         run: cd esp-wifi/ && cargo build --release --example=dhcp --target=xtensa-esp32s3-none-elf --features=esp32s3,embedded-svc,wifi
       - name: build (static_ip)
         run: cd esp-wifi/ && cargo build --release --example=static_ip --target=xtensa-esp32s3-none-elf --features=esp32s3,embedded-svc,wifi
+      - name: build (esp_now)
+        run: cd esp-wifi/ && cargo build --release --example=esp_now --target=xtensa-esp32s3-none-elf --features=esp32s3,esp-now
       - name: build (embassy_esp_now)
         run: cd esp-wifi/ && cargo build --release --example=embassy_esp_now --target=xtensa-esp32s3-none-elf --features=esp32s3,esp32s3-async,esp-now
       - name: build (embassy_dhcp)


### PR DESCRIPTION
- Add CI check for `esp_now,` `embassy_dhcp` and `embassy_esp_now`  examples

