### PR TITLE
Adjust for latest HAL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ opt-level = 3
 [profile.dev]
 # Explicitly disable LTO which the Xtensa codegen backend has issues
 lto = "off"
-
-[patch.crates-io]
-esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32c2-hal", rev = "f4c7bf809fcf0e57a852d7b2be175cc0c4c2895a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ opt-level = 3
 [profile.dev]
 # Explicitly disable LTO which the Xtensa codegen backend has issues
 lto = "off"
+
+[patch.crates-io]
+esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal", package = "esp32c2-hal", rev = "f4c7bf809fcf0e57a852d7b2be175cc0c4c2895a" }

--- a/esp-wifi/.cargo/config.toml
+++ b/esp-wifi/.cargo/config.toml
@@ -26,6 +26,9 @@ rustflags = [
 
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
+
+    # for now disable loop optimization
+    "-C", "target-feature=-loop",
 ]
 
 [target.xtensa-esp32s2-none-elf]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -8,17 +8,13 @@ license = "MIT OR Apache-2.0"
 embedded-hal = "0.2.3"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
-esp32c3-hal = { version = "0.5.0", optional = true }
-esp32c2-hal = { version = "0.3.0", optional = true }
-esp32-hal = { version = "0.8.0", optional = true, features = [ "rt" ] }
-esp32s3-hal = { version = "0.5.0", optional = true, features = [ "rt" ] }
-esp32s2-hal = { version = "0.5.0", optional = true, features = [ "rt" ] }
-esp32c3 = { version = "0.9.1",  features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.6.1",  features = ["critical-section"], optional = true }
-riscv-rt = { version = "0.11.0", optional = true }
-riscv = { version = "0.10.1", optional = true }
-xtensa-lx-rt = { version = "0.14.0", optional = true }
-xtensa-lx = { version = "0.7.0", optional = true }
+esp32c3-hal = { version = "0.7.0", optional = true }
+esp32c2-hal = { version = "0.5.0", optional = true }
+esp32-hal = { version = "0.10.0", optional = true, features = [ "rt" ] }
+esp32s3-hal = { version = "0.7.0", optional = true, features = [ "rt" ] }
+esp32s2-hal = { version = "0.7.0", optional = true, features = [ "rt" ] }
+esp32c3 = { version = "0.11.0",  features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.8.0",  features = ["critical-section"], optional = true }
 smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "1.1.1"
 atomic-polyfill = "1.0.1"
@@ -50,31 +46,30 @@ futures-util = { version = "0.3.17", default-features = false }
 
 [target.xtensa-esp32-none-elf.dev-dependencies]
 esp-println = { version = "0.3.1", features = [ "esp32", "log" ] }
-esp-backtrace = { version = "0.4.0", features = [ "esp32", "panic-handler", "exception-handler", "print-uart" ] }
+esp-backtrace = { version = "0.5.0", features = [ "esp32", "panic-handler", "exception-handler", "print-uart" ] }
 
 # change this for ESP32C3 / ESP32C2
 [target.riscv32imc-unknown-none-elf.dev-dependencies]
 esp-println = { version = "0.3.1", features = [ "esp32c3", "log" ] }
-esp-backtrace = { version = "0.4.0", features = [ "esp32c3", "panic-handler", "exception-handler", "print-uart" ] }
+esp-backtrace = { version = "0.5.0", features = [ "esp32c3", "panic-handler", "exception-handler", "print-uart" ] }
 
 [target.xtensa-esp32s3-none-elf.dev-dependencies]
 esp-println = { version = "0.3.1", features = [ "esp32s3", "log" ] }
-esp-backtrace = { version = "0.4.0", features = [ "esp32s3", "panic-handler", "exception-handler", "print-uart" ] }
+esp-backtrace = { version = "0.5.0", features = [ "esp32s3", "panic-handler", "exception-handler", "print-uart" ] }
 
 [target.xtensa-esp32s2-none-elf.dev-dependencies]
 esp-println = { version = "0.3.1", features = [ "esp32s2", "log", "critical-section" ] }
-esp-backtrace = { version = "0.4.0", features = [ "esp32s2", "panic-handler", "exception-handler", "print-uart" ] }
-xtensa-atomic-emulation-trap = "0.3.0"
+esp-backtrace = { version = "0.5.0", features = [ "esp32s2", "panic-handler", "exception-handler", "print-uart" ] }
 
 [features]
 default = [ "utils" ]
 
 # chip features
-esp32c3 = [ "riscv-target", "riscv", "riscv-rt", "esp32c3-hal", "dep:esp32c3", "esp-wifi-sys/esp32c3" ]
-esp32c2 = [ "riscv-target", "riscv", "riscv-rt", "esp32c2-hal", "dep:esp32c2", "esp-wifi-sys/esp32c2" ]
-esp32 = [ "esp32-hal", "xtensa-lx-rt/esp32", "xtensa-lx/esp32", "esp-wifi-sys/esp32" ]
-esp32s3 = [ "esp32s3-hal", "xtensa-lx-rt/esp32s3", "xtensa-lx/esp32s3", "esp-wifi-sys/esp32s3" ]
-esp32s2 = [ "esp32s2-hal", "xtensa-lx-rt/esp32s2", "xtensa-lx/esp32s2", "esp-wifi-sys/esp32s2" ]
+esp32c3 = [ "riscv-target", "esp32c3-hal", "dep:esp32c3", "esp-wifi-sys/esp32c3" ]
+esp32c2 = [ "riscv-target", "esp32c2-hal", "dep:esp32c2", "esp-wifi-sys/esp32c2" ]
+esp32 = [ "esp32-hal",  "esp-wifi-sys/esp32" ]
+esp32s3 = [ "esp32s3-hal", "esp-wifi-sys/esp32s3" ]
+esp32s2 = [ "esp32s2-hal", "esp-wifi-sys/esp32s2" ]
 
 # async features
 esp32c3-async = [ "esp32c3-hal/embassy", "esp32c3-hal/embassy-time-timg0", "async" ]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -9,7 +9,7 @@ embedded-hal = "0.2.3"
 nb = "1.0.0"
 void = { version = "1.0.2", default-features = false }
 esp32c3-hal = { version = "0.7.0", optional = true }
-esp32c2-hal = { version = "0.5.0", optional = true }
+esp32c2-hal = { version = "0.5.1", optional = true }
 esp32-hal = { version = "0.10.0", optional = true, features = [ "rt" ] }
 esp32s3-hal = { version = "0.7.0", optional = true, features = [ "rt" ] }
 esp32s2-hal = { version = "0.7.0", optional = true, features = [ "rt" ] }

--- a/esp-wifi/examples/access_point.rs
+++ b/esp-wifi/examples/access_point.rs
@@ -33,11 +33,7 @@ use hal::{peripherals::Peripherals, prelude::*, Rtc};
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
 use smoltcp::iface::SocketStorage;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp-wifi/examples/ble.rs
+++ b/esp-wifi/examples/ble.rs
@@ -28,10 +28,6 @@ use hal::{
     prelude::*,
     Rng, Rtc, IO,
 };
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3"))]
-use xtensa_lx_rt::entry;
 
 #[entry]
 fn main() -> ! {

--- a/esp-wifi/examples/coex.rs
+++ b/esp-wifi/examples/coex.rs
@@ -38,11 +38,6 @@ use smoltcp::{iface::SocketStorage, wire::Ipv4Address};
 #[cfg(feature = "esp32c3")]
 use hal::system::SystemExt;
 
-#[cfg(feature = "esp32c3")]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3"))]
-use xtensa_lx_rt::entry;
-
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -32,11 +32,6 @@ use smoltcp::wire::Ipv4Address;
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
-
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 

--- a/esp-wifi/examples/embassy_access_point.rs
+++ b/esp-wifi/examples/embassy_access_point.rs
@@ -35,11 +35,6 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
-
 macro_rules! singleton {
     ($val:expr) => {{
         type T = impl Sized;

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -31,11 +31,6 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
-
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");
 

--- a/esp-wifi/examples/embassy_esp_now.rs
+++ b/esp-wifi/examples/embassy_esp_now.rs
@@ -30,11 +30,6 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
-
 #[embassy_executor::task]
 async fn run(mut esp_now: EspNow) {
     let mut ticker = Ticker::every(Duration::from_secs(5));

--- a/esp-wifi/examples/esp_now.rs
+++ b/esp-wifi/examples/esp_now.rs
@@ -24,11 +24,6 @@ use hal::{peripherals::Peripherals, prelude::*, Rtc};
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
-
 #[entry]
 fn main() -> ! {
     init_logger(log::LevelFilter::Info);

--- a/esp-wifi/examples/static_ip.rs
+++ b/esp-wifi/examples/static_ip.rs
@@ -31,11 +31,7 @@ use hal::{peripherals::Peripherals, prelude::*, Rtc};
 #[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
 use hal::system::SystemExt;
 
-#[cfg(any(feature = "esp32c3", feature = "esp32c2"))]
-use riscv_rt::entry;
 use smoltcp::iface::SocketStorage;
-#[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32s2"))]
-use xtensa_lx_rt::entry;
 
 const SSID: &str = env!("SSID");
 const PASSWORD: &str = env!("PASSWORD");

--- a/esp-wifi/smoketest.bat
+++ b/esp-wifi/smoketest.bat
@@ -34,12 +34,13 @@ cargo "+esp" run --example embassy_esp_now --release --target xtensa-esp32-none-
 cargo "+esp" run --example access_point --release --target xtensa-esp32-none-elf --features "esp32,embedded-svc,wifi"
 cargo "+esp" run --example embassy_access_point --release --target xtensa-esp32-none-elf --features "esp32,esp32-async,embedded-svc,wifi,embassy-net"
 
-set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
+set CARGO_PROFILE_RELEASE_OPT_LEVEL=1
 set CARGO_PROFILE_RELEASE_LTO=off
 echo.
 echo Connect ESP32-S3
 pause
 cargo "+esp" run --example ble --release --target xtensa-esp32s3-none-elf --features "esp32s3,ble"
+set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 cargo "+esp" run --example dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"
 cargo "+esp" run --example static_ip --release --target xtensa-esp32s3-none-elf --features "esp32s3,embedded-svc,wifi"
 cargo "+esp" run --example embassy_dhcp --release --target xtensa-esp32s3-none-elf --features "esp32s3,esp32s3-async,embedded-svc,wifi,embassy-net"

--- a/esp-wifi/smoketest.bat
+++ b/esp-wifi/smoketest.bat
@@ -62,12 +62,13 @@ cargo "+esp" run --example embassy_esp_now --release --target xtensa-esp32s2-non
 cargo "+esp" run --example access_point --release --target xtensa-esp32s2-none-elf --features "esp32s2,embedded-svc,wifi"
 cargo "+esp" run --example embassy_access_point --release --target xtensa-esp32s2-none-elf --features "esp32s2,esp32s2-async,embedded-svc,wifi,embassy-net"
 
-set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
+set CARGO_PROFILE_RELEASE_OPT_LEVEL=2
 set CARGO_PROFILE_RELEASE_LTO=false
 echo.
 echo Connect ESP32-C2 and modify the 'target.riscv32imc-unknown-none-elf.dev-dependencies' section
 pause
 cargo "+nightly" run --example ble --release --target riscv32imc-unknown-none-elf --features "esp32c2,ble"
+set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 cargo "+nightly" run --example dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"
 cargo "+nightly" run --example static_ip --release --target riscv32imc-unknown-none-elf --features "esp32c2,embedded-svc,wifi"
 cargo "+nightly" run --example embassy_dhcp --release --target riscv32imc-unknown-none-elf --features "esp32c2,esp32c2-async,embedded-svc,wifi,embassy-net"

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -906,7 +906,7 @@ unsafe extern "C" fn ble_npl_eventq_put(queue: *const ble_npl_eventq, event: *co
             .as_mut()
             .unwrap()
             .queued = true;
-        EVENT_QUEUE.enqueue((*event).dummy as usize);
+        EVENT_QUEUE.enqueue((*event).dummy as usize).unwrap();
     });
 }
 

--- a/esp-wifi/src/ble/os_adapter_esp32.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32.rs
@@ -531,7 +531,7 @@ pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: 
 
 pub(crate) unsafe extern "C" fn ints_on(mask: u32) {
     log::trace!("chip_ints_on esp32 {:b}", mask);
-    xtensa_lx::interrupt::enable_mask(mask);
+    hal::xtensa_lx::interrupt::enable_mask(mask);
 }
 
 #[cfg(coex)]

--- a/esp-wifi/src/ble/os_adapter_esp32s3.rs
+++ b/esp-wifi/src/ble/os_adapter_esp32s3.rs
@@ -179,7 +179,7 @@ pub(crate) fn create_ble_config() -> esp_bt_controller_config_t {
 pub(crate) unsafe extern "C" fn interrupt_on(intr_num: i32) {
     log::trace!("interrupt_on {}", intr_num);
     unsafe {
-        xtensa_lx::interrupt::enable_mask(1 << 1);
+        esp32s3_hal::xtensa_lx::interrupt::enable_mask(1 << 1);
     }
 }
 

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -21,8 +21,6 @@ use esp32s2_hal as hal;
 #[cfg(feature = "esp32s3")]
 use esp32s3_hal as hal;
 
-use hal::*;
-
 use fugit::MegahertzU32;
 use hal::clock::Clocks;
 use linked_list_allocator::Heap;
@@ -74,12 +72,6 @@ use timer::{get_systimer_count, TICKS_PER_SECOND};
 
 #[cfg(all(feature = "embedded-svc", feature = "wifi"))]
 pub mod wifi_interface;
-
-#[cfg(feature = "esp32c3")]
-use esp32c3_hal::interrupt;
-
-#[cfg(feature = "esp32c2")]
-use esp32c2_hal::interrupt;
 
 pub fn current_millis() -> u64 {
     get_systimer_count() / (TICKS_PER_SECOND / 1000)

--- a/esp-wifi/src/preempt/preempt_xtensa.rs
+++ b/esp-wifi/src/preempt/preempt_xtensa.rs
@@ -1,13 +1,13 @@
 use super::*;
-use xtensa_lx_rt::exception::Context;
+use crate::hal::trapframe::TrapFrame;
 
 #[derive(Debug, Clone, Copy)]
 pub struct TaskContext {
-    trap_frame: Context,
+    trap_frame: TrapFrame,
 }
 
 static mut CTX_TASKS: [TaskContext; MAX_TASK] = [TaskContext {
-    trap_frame: Context {
+    trap_frame: TrapFrame {
         PC: 0,
         PS: 0,
         A0: 0,
@@ -96,7 +96,7 @@ pub fn task_create(task: extern "C" fn()) -> usize {
     }
 }
 
-pub fn task_to_trap_frame(id: usize, trap_frame: &mut Context) {
+pub fn task_to_trap_frame(id: usize, trap_frame: &mut TrapFrame) {
     unsafe {
         trap_frame.PC = CTX_TASKS[id].trap_frame.PC;
         trap_frame.PS = CTX_TASKS[id].trap_frame.PS;
@@ -155,7 +155,7 @@ pub fn task_to_trap_frame(id: usize, trap_frame: &mut Context) {
     }
 }
 
-pub fn trap_frame_to_task(id: usize, trap_frame: &Context) {
+pub fn trap_frame_to_task(id: usize, trap_frame: &TrapFrame) {
     unsafe {
         CTX_TASKS[id].trap_frame.PC = trap_frame.PC;
         CTX_TASKS[id].trap_frame.PS = trap_frame.PS;
@@ -220,7 +220,7 @@ pub fn next_task() {
     }
 }
 
-pub fn task_switch(trap_frame: &mut Context) {
+pub fn task_switch(trap_frame: &mut TrapFrame) {
     unsafe {
         if FIRST_SWITCH.load(Ordering::Relaxed) {
             FIRST_SWITCH.store(false, Ordering::Relaxed);

--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -2,6 +2,9 @@ use core::cell::RefCell;
 
 use atomic_polyfill::{AtomicU64, Ordering};
 use critical_section::Mutex;
+use esp32_hal::xtensa_lx;
+use esp32_hal::xtensa_lx_rt;
+use esp32_hal::xtensa_lx_rt::exception::Context;
 use esp32_hal::{
     interrupt,
     peripherals::{self, TIMG1},
@@ -9,7 +12,6 @@ use esp32_hal::{
     timer::{Timer, Timer0},
 };
 use log::trace;
-use xtensa_lx_rt::exception::Context;
 
 use crate::preempt::preempt::task_switch;
 use esp32_hal::macros::interrupt;

--- a/esp-wifi/src/timer_esp32c2.rs
+++ b/esp-wifi/src/timer_esp32c2.rs
@@ -52,11 +52,14 @@ pub fn setup_timer_isr(systimer: Alarm<Target, 0>) {
             .unwrap();
     }
 
-    esp32c2_hal::interrupt::enable(Interrupt::SW_INTR_3, hal::interrupt::Priority::Priority1)
-        .unwrap();
+    esp32c2_hal::interrupt::enable(
+        Interrupt::ETS_FROM_CPU_INTR3,
+        hal::interrupt::Priority::Priority1,
+    )
+    .unwrap();
 
     unsafe {
-        riscv::interrupt::enable();
+        esp32c2_hal::riscv::interrupt::enable();
     }
 
     while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
@@ -155,9 +158,9 @@ fn SYSTIMER_TARGET0(trap_frame: &mut TrapFrame) {
 }
 
 #[interrupt]
-fn SW_INTR_3(trap_frame: &mut TrapFrame) {
+fn ETS_FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
     unsafe {
-        // clear SW_INTR_3
+        // clear ETS_FROM_CPU_INTR3
         (&*pac::SYSTEM::PTR)
             .cpu_intr_from_cpu_3
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());

--- a/esp-wifi/src/timer_esp32s2.rs
+++ b/esp-wifi/src/timer_esp32s2.rs
@@ -2,6 +2,9 @@ use core::cell::RefCell;
 
 use atomic_polyfill::{AtomicU64, Ordering};
 use critical_section::Mutex;
+use esp32s2_hal::xtensa_lx;
+use esp32s2_hal::xtensa_lx_rt;
+use esp32s2_hal::xtensa_lx_rt::exception::Context;
 use esp32s2_hal::{
     interrupt,
     peripherals::{self, TIMG1},
@@ -9,7 +12,6 @@ use esp32s2_hal::{
     timer::{Timer, Timer0},
 };
 use log::trace;
-use xtensa_lx_rt::exception::Context;
 
 use crate::preempt::preempt::task_switch;
 use esp32s2_hal::macros::interrupt;

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -54,7 +54,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
 
     #[cfg(feature = "wifi")]
     interrupt::enable(
-        peripherals::Interrupt::WIFI_BB,
+        peripherals::Interrupt::WIFI_PWR,
         interrupt::Priority::Priority1,
     )
     .unwrap();
@@ -62,12 +62,12 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     #[cfg(feature = "ble")]
     {
         interrupt::enable(
-            peripherals::Interrupt::BT_BB_NMI,
+            peripherals::Interrupt::BT_BB,
             interrupt::Priority::Priority1,
         )
         .unwrap();
         interrupt::enable(
-            peripherals::Interrupt::RWBT_NMI,
+            peripherals::Interrupt::RWBLE,
             interrupt::Priority::Priority1,
         )
         .unwrap();
@@ -118,10 +118,10 @@ fn WIFI_MAC() {
 
 #[cfg(feature = "wifi")]
 #[interrupt]
-fn WIFI_BB() {
+fn WIFI_PWR() {
     unsafe {
         let (fnc, arg) = crate::wifi::os_adapter::ISR_INTERRUPT_1;
-        trace!("interrupt WIFI_BB {:p} {:p}", fnc, arg);
+        trace!("interrupt WIFI_PWR {:p} {:p}", fnc, arg);
 
         if !fnc.is_null() {
             let fnc: fn(*mut crate::binary::c_types::c_void) = core::mem::transmute(fnc);
@@ -134,10 +134,10 @@ fn WIFI_BB() {
 
 #[cfg(feature = "ble")]
 #[interrupt]
-fn RWBT_NMI() {
+fn RWBLE() {
     critical_section::with(|_| unsafe {
         let (fnc, arg) = crate::ble::btdm::ble_os_adapter_chip_specific::ISR_INTERRUPT_5;
-        trace!("interrupt RWBT_NMI {:p} {:p}", fnc, arg);
+        trace!("interrupt RWBLE {:p} {:p}", fnc, arg);
         if !fnc.is_null() {
             let fnc: fn(*mut crate::binary::c_types::c_void) = core::mem::transmute(fnc);
             fnc(arg);
@@ -147,7 +147,7 @@ fn RWBT_NMI() {
 
 #[cfg(feature = "ble")]
 #[interrupt]
-fn BT_BB_NMI() {
+fn BT_BB() {
     critical_section::with(|_| unsafe {
         let (fnc, arg) = crate::ble::btdm::ble_os_adapter_chip_specific::ISR_INTERRUPT_8;
         trace!("interrupt RWBT {:p} {:p}", fnc, arg);

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -2,6 +2,7 @@ use core::cell::RefCell;
 
 use atomic_polyfill::{AtomicU64, Ordering};
 use critical_section::Mutex;
+use esp32s3_hal::trapframe::TrapFrame;
 use esp32s3_hal::{
     interrupt,
     peripherals::{self, TIMG1},
@@ -9,7 +10,6 @@ use esp32s3_hal::{
     timer::{Timer, Timer0},
 };
 use log::trace;
-use xtensa_lx_rt::exception::Context;
 
 use crate::preempt::preempt::task_switch;
 use esp32s3_hal::macros::interrupt;
@@ -33,7 +33,7 @@ pub fn get_systimer_count() -> u64 {
 
 #[inline(always)]
 fn read_timer_value() -> u64 {
-    let value = xtensa_lx::timer::get_cycle_count() as u64;
+    let value = esp32s3_hal::xtensa_lx::timer::get_cycle_count() as u64;
     value * 40_000_000 / 240_000_000
 }
 
@@ -79,15 +79,15 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
 
-    xtensa_lx::timer::set_ccompare0(0xffffffff);
+    esp32s3_hal::xtensa_lx::timer::set_ccompare0(0xffffffff);
 
     unsafe {
-        xtensa_lx::interrupt::disable();
-        xtensa_lx::interrupt::enable_mask(
+        esp32s3_hal::xtensa_lx::interrupt::disable();
+        esp32s3_hal::xtensa_lx::interrupt::enable_mask(
             1 << 6 // Timer0
             | 1 << 29 // Software1
-                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
-                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
+                | esp32s3_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
+                | esp32s3_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
         );
     }
 
@@ -99,7 +99,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
 fn Timer0(_level: u32) {
     TIME.fetch_add(0x1_0000_0000 * 40_000_000 / 240_000_000, Ordering::Relaxed);
 
-    xtensa_lx::timer::set_ccompare0(0xffffffff);
+    esp32s3_hal::xtensa_lx::timer::set_ccompare0(0xffffffff);
 }
 
 #[cfg(feature = "wifi")]
@@ -160,7 +160,7 @@ fn BT_BB_NMI() {
 }
 
 #[interrupt]
-fn TG1_T0_LEVEL(context: &mut Context) {
+fn TG1_T0_LEVEL(context: &mut TrapFrame) {
     task_switch(context);
 
     critical_section::with(|cs| {
@@ -175,7 +175,7 @@ fn TG1_T0_LEVEL(context: &mut Context) {
 
 #[allow(non_snake_case)]
 #[no_mangle]
-fn Software1(_level: u32, context: &mut Context) {
+fn Software1(_level: u32, context: &mut TrapFrame) {
     let intr = 1 << 29;
     unsafe {
         core::arch::asm!("wsr.227  {0}", in(reg) intr, options(nostack)); // 227 = "intclear"

--- a/esp-wifi/src/wifi/os_adapter_esp32.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32.rs
@@ -13,7 +13,7 @@ const DPORT_WIFI_CLK_WIFI_EN_M: u32 = (DPORT_WIFI_CLK_WIFI_EN_V) << (DPORT_WIFI_
 pub(crate) fn chip_ints_on(mask: u32) {
     trace!("chip_ints_on esp32");
     unsafe {
-        xtensa_lx::interrupt::enable_mask(1 << 0);
+        esp32_hal::xtensa_lx::interrupt::enable_mask(1 << 0);
     }
 }
 

--- a/esp-wifi/src/wifi/os_adapter_esp32c2.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c2.rs
@@ -18,12 +18,12 @@ pub(crate) fn chip_ints_on(mask: u32) {
 pub(crate) unsafe extern "C" fn wifi_int_disable(
     wifi_int_mux: *mut crate::binary::c_types::c_void,
 ) -> u32 {
-    let res = if riscv::register::mstatus::read().mie() {
+    let res = if esp32c2_hal::riscv::register::mstatus::read().mie() {
         1
     } else {
         0
     };
-    riscv::interrupt::disable();
+    esp32c2_hal::riscv::interrupt::disable();
 
     trace!(
         "wifi_int_disable wifi_int_mux {:p} - return {}",
@@ -45,7 +45,7 @@ pub(crate) unsafe extern "C" fn wifi_int_restore(
     );
 
     if tmp == 1 {
-        riscv::interrupt::enable();
+        esp32c2_hal::riscv::interrupt::enable();
     }
 }
 

--- a/esp-wifi/src/wifi/os_adapter_esp32c3.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c3.rs
@@ -1,3 +1,4 @@
+use esp32c3_hal::riscv;
 use log::trace;
 
 pub(crate) fn chip_ints_on(mask: u32) {

--- a/esp-wifi/src/wifi/os_adapter_esp32s2.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32s2.rs
@@ -6,7 +6,7 @@ use log::trace;
 pub(crate) fn chip_ints_on(mask: u32) {
     trace!("chip_ints_on esp32");
     unsafe {
-        xtensa_lx::interrupt::enable_mask(1 << 0);
+        esp32s2_hal::xtensa_lx::interrupt::enable_mask(1 << 0);
     }
 }
 

--- a/esp-wifi/src/wifi/os_adapter_esp32s3.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32s3.rs
@@ -6,7 +6,7 @@ use log::trace;
 pub(crate) fn chip_ints_on(mask: u32) {
     trace!("chip_ints_on esp32");
     unsafe {
-        xtensa_lx::interrupt::enable_mask(1 << 0);
+        esp32s3_hal::xtensa_lx::interrupt::enable_mask(1 << 0);
     }
 }
 


### PR DESCRIPTION
This adjusts the code to work with the currently released HAL

TODO
- [x] needs a bugfixed ESP32-C2 HAL
- [x] none of the examples work on ESP32-S3 anymore
- [x] ESP32-C2 BLE example only works in opt-level 2

Closes #138
