### PR TITLE
Add missing ROM functions for ESP32-S3/ESP32-S2

### DIFF
--- a/esp-wifi-sys/ld/esp32s2/rom_functions.x
+++ b/esp-wifi-sys/ld/esp32s2/rom_functions.x
@@ -68,3 +68,8 @@ strncmp = 0x4001ae64;
 /* from esp32s3.rom.libgcc.ld*/
 __popcountsi2 = 0x40008fa8;
 __bswapsi2 = 0x40006d0c;
+
+/* from esp32s3.rom.newlib.ld */
+strcmp = 0x40007be4;
+strstr = 0x4001aee8;
+strchr = 0x4001adb0;

--- a/esp-wifi-sys/ld/esp32s3/rom_functions.x
+++ b/esp-wifi-sys/ld/esp32s3/rom_functions.x
@@ -2281,3 +2281,8 @@ PROVIDE ( esp_rom_delay_us = ets_delay_us );
 /* from esp32s3.rom.libgcc.ld*/
 __popcountsi2 = 0x400024d8;
 __bswapsi2 = 0x400021d8;
+
+/* from esp32s3.rom.newlib.ld */
+strcmp = 0x40001230;
+strstr = 0x40001254;
+strchr = 0x4000138c;

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -92,8 +92,11 @@ const HEAP_SIZE: usize = 64 * 1024;
 #[cfg(all(coex, not(feature = "big-heap")))]
 const HEAP_SIZE: usize = 64 * 1024;
 
-#[cfg(all(not(coex), feature = "big-heap"))]
+#[cfg(all(not(coex), not(feature = "esp32s2"), feature = "big-heap"))]
 const HEAP_SIZE: usize = 100 * 1024;
+
+#[cfg(all(not(coex), feature = "esp32s2", feature = "big-heap"))]
+const HEAP_SIZE: usize = 72 * 1024;
 
 #[cfg(all(coex, feature = "big-heap"))]
 const HEAP_SIZE: usize = 100 * 1024;


### PR DESCRIPTION
There were some ROM functions needed by `mbedtls` which were missing for ESP32-S3/ESP32-S2
