### PR TITLE
Fix DHCP handling

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1195,7 +1195,10 @@ impl embedded_svc::wifi::Wifi for WifiController<'_> {
     }
 
     fn connect(&mut self) -> Result<(), Self::Error> {
-        esp_wifi_result!(unsafe { esp_wifi_connect() })
+        esp_wifi_result!(unsafe {
+            WIFI_STATE = -1;
+            esp_wifi_connect()
+        })
     }
 
     fn disconnect(&mut self) -> Result<(), Self::Error> {

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -38,8 +38,11 @@ pub fn create_network_interface<'a, 'd>(
 
     let mut socket_set = SocketSet::new(socket_set_entries);
 
-    let dhcp_socket = Dhcpv4Socket::new();
-    socket_set.add(dhcp_socket);
+    if !mode.is_ap() {
+        // only add DHCP client in STA mode
+        let dhcp_socket = Dhcpv4Socket::new();
+        socket_set.add(dhcp_socket);
+    }
 
     (iface, device, controller, socket_set)
 }

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -59,6 +59,25 @@ impl<'a> WifiStack<'a> {
         }
     }
 
+    pub fn reset(&self) {
+        log::debug!("Reset TCP stack");
+
+        if let Some(dhcp_handle) = self.dhcp_socket_handle {
+            self.with_mut(|_, _, sockets| {
+                let dhcp_socket = sockets.get_mut::<Dhcpv4Socket>(dhcp_handle);
+                log::debug!("Reset DHCP client");
+                dhcp_socket.reset();
+            });
+        }
+
+        self.with_mut(|interface, _, _| {
+            interface.routes_mut().remove_default_ipv4_route();
+            interface.update_ip_addrs(|addrs| {
+                addrs.clear();
+            });
+        });
+    }
+
     /// Convenience function to poll the DHCP socket.
     pub fn poll_dhcp(
         &self,
@@ -245,7 +264,10 @@ impl<'a> ipv4::Interface for WifiStack<'a> {
             dhcp_socket.reset();
 
             // remove the DHCP client if we use a static IP
-            if matches!(conf, ipv4::Configuration::Client(ipv4::ClientConfiguration::Fixed(_))) {
+            if matches!(
+                conf,
+                ipv4::Configuration::Client(ipv4::ClientConfiguration::Fixed(_))
+            ) {
                 self.sockets.get_mut().remove(dhcp_handle);
                 self.dhcp_socket_handle = None;
             }


### PR DESCRIPTION
This fixes DHCP handling (for the polling interface, seems like the embassy-net is fine)

First problem was: Even with a static IP there was the DHCP-socket which requested an IP.

Second problem: When trying to disconnect from an AP and connect to another AP there was no way to reset the TCP stack so it kept the old IP and routes

Just to have it somewhere here is the `dhcp.rs` modified to connect to one AP and then to another
```rust
#![no_std]
#![no_main]

use examples_util::hal;

use embedded_io::blocking::*;
use embedded_svc::ipv4::Interface;
use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};

use esp_backtrace as _;
use esp_println::logger::init_logger;
use esp_println::{print, println};
use esp_wifi::wifi::utils::create_network_interface;
use esp_wifi::wifi::WifiMode;
use esp_wifi::wifi_interface::WifiStack;
use esp_wifi::{current_millis, initialize};
use hal::clock::{ClockControl, CpuClock};
use hal::Rng;
use hal::{peripherals::Peripherals, prelude::*, Rtc};
use smoltcp::iface::SocketStorage;
use smoltcp::wire::Ipv4Address;

const SSID: &str = env!("SSID");
const PASSWORD: &str = env!("PASSWORD");

const SSID1: &str = env!("SSID1");
const PASSWORD1: &str = env!("PASSWORD1");

#[entry]
fn main() -> ! {
    init_logger(log::LevelFilter::Info);

    let peripherals = Peripherals::take();

    let system = examples_util::system!(peripherals);
    let mut peripheral_clock_control = system.peripheral_clock_control;
    let clocks = examples_util::clocks!(system);
    examples_util::rtc!(peripherals);

    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
    initialize(
        timer,
        Rng::new(peripherals.RNG),
        system.radio_clock_control,
        &clocks,
    )
    .unwrap();

    let mut rx_buffer = [0u8; 1536];
    let mut tx_buffer = [0u8; 1536];

    let wifi = examples_util::get_wifi!(peripherals);
    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
    let (iface, device, mut controller, sockets) =
        create_network_interface(wifi, WifiMode::Sta, &mut socket_set_entries);
    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
    wifi_stack.reset();

    let client_config = Configuration::Client(ClientConfiguration {
        ssid: SSID.into(),
        password: PASSWORD.into(),
        ..Default::default()
    });
    let res = controller.set_configuration(&client_config);
    println!("wifi_set_configuration returned {:?}", res);

    controller.start().unwrap();
    println!("is wifi started: {:?}", controller.is_started());

    println!("{:?}", controller.get_capabilities());
    println!("wifi_connect {:?}", controller.connect());

    // wait to get connected
    println!("Wait to get connected");
    loop {
        let res = controller.is_connected();
        match res {
            Ok(connected) => {
                if connected {
                    break;
                }
            }
            Err(err) => {
                println!("{:?}", err);
                loop {}
            }
        }
    }
    println!("{:?}", controller.is_connected());

    // wait for getting an ip address
    println!("Wait to get an ip address");
    loop {
        wifi_stack.work();

        if wifi_stack.is_iface_up() {
            println!("got ip {:?}", wifi_stack.get_ip_info());
            break;
        }
    }

    println!("Start busy loop on main");

    let mut socket = wifi_stack.get_socket(&mut rx_buffer, &mut tx_buffer);

    loop {
        println!("Making HTTP request");
        socket.work();

        socket
            .open(Ipv4Address::new(142, 250, 185, 115), 80)
            .unwrap();

        socket
            .write(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
            .unwrap();
        socket.flush().unwrap();

        let wait_end = current_millis() + 20 * 1000;
        loop {
            let mut buffer = [0u8; 512];
            if let Ok(len) = socket.read(&mut buffer) {
                let to_print = unsafe { core::str::from_utf8_unchecked(&buffer[..len]) };
                print!("{}", to_print);
            } else {
                break;
            }

            if current_millis() > wait_end {
                println!("Timeout");
                break;
            }
        }
        println!();

        socket.disconnect();

        let wait_end = current_millis() + 1 * 1000;
        while current_millis() < wait_end {
            socket.work();
        }

        break;
    }

    // --- try with other AP

    let res = controller.disconnect();
    println!("Disconnect result {:?}", res);

    wifi_stack.reset();

    let client_config = Configuration::Client(ClientConfiguration {
        ssid: SSID1.into(),
        password: PASSWORD1.into(),
        ..Default::default()
    });
    let res = controller.set_configuration(&client_config);
    println!("wifi_set_configuration returned {:?}", res);

    println!("wifi_connect {:?}", controller.connect());

    // wait to get connected
    println!("Wait to get connected");
    loop {
        let res = controller.is_connected();
        match res {
            Ok(connected) => {
                if connected {
                    break;
                }
            }
            Err(err) => {
                println!("{:?}", err);
                loop {}
            }
        }
    }
    println!("{:?}", controller.is_connected());

    // wait for getting an ip address
    println!("Wait to get an ip address");
    loop {
        wifi_stack.work();

        if wifi_stack.is_iface_up() {
            println!("got ip {:?}", wifi_stack.get_ip_info());
            break;
        }
    }

    println!("Start busy loop on main");

    loop {
        println!("Making HTTP request");
        socket.work();

        socket
            .open(Ipv4Address::new(142, 250, 185, 115), 80)
            .unwrap();

        socket
            .write(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
            .unwrap();
        socket.flush().unwrap();

        let wait_end = current_millis() + 20 * 1000;
        loop {
            let mut buffer = [0u8; 512];
            if let Ok(len) = socket.read(&mut buffer) {
                let to_print = unsafe { core::str::from_utf8_unchecked(&buffer[..len]) };
                print!("{}", to_print);
            } else {
                break;
            }

            if current_millis() > wait_end {
                println!("Timeout");
                break;
            }
        }
        println!();

        socket.disconnect();

        let wait_end = current_millis() + 5 * 1000;
        while current_millis() < wait_end {
            socket.work();
        }

        break;
    }

    println!("Done");

    loop {
        socket. Work();
    }
}
```
