### PR TITLE
fix(esp-wifi): Update is_started() implementation

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1212,7 +1212,12 @@ impl embedded_svc::wifi::Wifi for WifiController<'_> {
     }
 
     fn is_started(&self) -> Result<bool, Self::Error> {
-        Ok(self.is_sta_enabled()? || self.is_ap_enabled()?)
+        match crate::wifi::get_wifi_state() {
+            crate::wifi::WifiState::Invalid => Ok(false),
+            // We assume that wifi has been started in every other states
+            _ => Ok(true)
+        }
+
     }
 
     fn is_connected(&self) -> Result<bool, Self::Error> {


### PR DESCRIPTION
The old implementation of `is_started()` returns `Ok(true)` is the sta or ap is enabled, which is true before `wifi_start()` has been called. This results in the function returning true, before `start()` has been called.

This can be tested by calling `is_started()` before `start()` has been called