### PR TITLE
preempt improvements

### DIFF
--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -21,9 +21,9 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -54,13 +54,6 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     )
     .unwrap();
 
-    #[cfg(feature = "wifi")]
-    interrupt::enable(
-        peripherals::Interrupt::WIFI_BB,
-        interrupt::Priority::Priority1,
-    )
-    .unwrap();
-
     #[cfg(feature = "ble")]
     {
         interrupt::enable(peripherals::Interrupt::RWBT, interrupt::Priority::Priority1).unwrap();
@@ -127,22 +120,6 @@ fn WIFI_MAC() {
             fnc(arg);
         }
     }
-}
-
-#[cfg(feature = "wifi")]
-#[interrupt]
-fn WIFI_BB() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::os_adapter::ISR_INTERRUPT_1;
-        trace!("interrupt WIFI_BB {:p} {:p}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut crate::binary::c_types::c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
 }
 
 #[cfg(feature = "ble")]

--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -21,9 +21,9 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(4000);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(500);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 
@@ -72,7 +72,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     }
 
     timer1.listen();
-    timer1.start(TIMER_DELAY.convert());
+    timer1.start(TIMER_DELAY.into_duration());
     critical_section::with(|cs| {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
@@ -197,7 +197,7 @@ fn TG1_T0_LEVEL(context: &mut Context) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 
@@ -217,7 +217,7 @@ fn Software1(_level: u32, context: &mut Context) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 

--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -80,12 +80,12 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     xtensa_lx::timer::set_ccompare0(0xffffffff);
 
     unsafe {
-        xtensa_lx::interrupt::disable();
+        let enabled = esp32_hal::xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
             1 << 6 // Timer0
             | 1 << 29 // Software1
                 | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
-                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
+                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask() | enabled,
         );
     }
 

--- a/esp-wifi/src/timer_esp32c2.rs
+++ b/esp-wifi/src/timer_esp32c2.rs
@@ -16,9 +16,9 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32c3.rs
+++ b/esp-wifi/src/timer_esp32c3.rs
@@ -16,9 +16,9 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32c6.rs
+++ b/esp-wifi/src/timer_esp32c6.rs
@@ -16,9 +16,9 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32s2.rs
+++ b/esp-wifi/src/timer_esp32s2.rs
@@ -21,9 +21,9 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32s2.rs
+++ b/esp-wifi/src/timer_esp32s2.rs
@@ -70,12 +70,12 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     xtensa_lx::timer::set_ccompare0(0xffffffff);
 
     unsafe {
-        xtensa_lx::interrupt::disable();
+        let enabled = esp32s2_hal::xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
             1 << 6 // Timer0
             | 1 << 29 // Software1
                 | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
-                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
+                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask() | enabled,
         );
     }
 

--- a/esp-wifi/src/timer_esp32s2.rs
+++ b/esp-wifi/src/timer_esp32s2.rs
@@ -21,9 +21,9 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(4000);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(500);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(500);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(1_000);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 
@@ -62,7 +62,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     .unwrap();
 
     timer1.listen();
-    timer1.start(TIMER_DELAY.convert());
+    timer1.start(TIMER_DELAY.into_duration());
     critical_section::with(|cs| {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
@@ -131,7 +131,7 @@ fn TG1_T0_LEVEL(context: &mut Context) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 
@@ -151,7 +151,7 @@ fn Software1(_level: u32, context: &mut Context) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -82,12 +82,12 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     esp32s3_hal::xtensa_lx::timer::set_ccompare0(0xffffffff);
 
     unsafe {
-        esp32s3_hal::xtensa_lx::interrupt::disable();
+        let enabled = esp32s3_hal::xtensa_lx::interrupt::disable();
         esp32s3_hal::xtensa_lx::interrupt::enable_mask(
             1 << 6 // Timer0
             | 1 << 29 // Software1
                 | esp32s3_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
-                | esp32s3_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
+                | esp32s3_hal::xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask() | enabled,
         );
     }
 

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -19,7 +19,7 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(500);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
 #[cfg(not(debug_assertions))]
 const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
 

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -21,7 +21,7 @@ pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 #[cfg(debug_assertions)]
 const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(500);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(1_000);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -19,9 +19,9 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
 #[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(4000);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(500);
 #[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::MicrosDurationU64 = fugit::MicrosDurationU64::micros(500);
+const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(1_000);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 
@@ -74,7 +74,7 @@ pub fn setup_timer_isr(timg1_timer0: Timer<Timer0<TIMG1>>) {
     }
 
     timer1.listen();
-    timer1.start(TIMER_DELAY.convert());
+    timer1.start(TIMER_DELAY.into_duration());
     critical_section::with(|cs| {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
@@ -169,7 +169,7 @@ fn TG1_T0_LEVEL(context: &mut TrapFrame) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 
@@ -189,7 +189,7 @@ fn Software1(_level: u32, context: &mut TrapFrame) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = timer.as_mut().unwrap();
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.convert());
+        timer.start(TIMER_DELAY.into_duration());
     });
 }
 


### PR DESCRIPTION
First, commit fixes a bug discovered by @bugadani, where preconfigured interrupts were disabled once the preempt module started.

The second commit reduces the task switching frequency on Xtensa to the same values as on RISCV. This should improve performance as less time will now be spent in the switching code. ~~We should do some profiling at some point to determine the best default value for this (I still think 1000hz could be too high), but for now 1000hz seems reasonable.~~ It's no set to 100hz.

Closes #184