### PR TITLE
Remove uneeded instrinsic stub

### DIFF
--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -469,6 +469,7 @@ pub unsafe extern "C" fn strrchr(_s: *const (), _c: u32) -> *const u8 {
 }
 
 #[no_mangle]
+#[linkage = "weak"]
 pub unsafe extern "C" fn floor(_v: f64) -> f64 {
     todo!("floor")
 }

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![feature(c_variadic)]
+#![feature(linkage)]
 #![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 #![cfg_attr(feature = "async", allow(incomplete_features))]
 


### PR DESCRIPTION
The changes from https://github.com/rust-lang/compiler-builtins/pull/517 have landed.

I suppose this might break stuff for people who don't upgrade to 1.70, but they can always add there own stub if they want.