### PR TITLE
Make ESP32-C2 BLE work again

### DIFF
--- a/smoketest.bat
+++ b/smoketest.bat
@@ -72,14 +72,13 @@ cargo run --example access_point --release --features "wifi"
 cargo run --example embassy_access_point --release --features "async,wifi,embassy-net"
 
 cd ..\examples-esp32c2
-set CARGO_PROFILE_RELEASE_OPT_LEVEL=2
+set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 set CARGO_PROFILE_RELEASE_LTO=false
 echo.
 echo Connect ESP32-C2
 pause
 cargo run --example ble --release --features "ble"
 cargo run --example async_ble --release --features "async,ble"
-set CARGO_PROFILE_RELEASE_OPT_LEVEL=3
 cargo run --example dhcp --release --features "wifi"
 cargo run --example static_ip --release --features "wifi"
 cargo run --example embassy_dhcp --release --features "async,wifi,embassy-net"


### PR DESCRIPTION
After lowering the task-switching frequency, ESP32-C2 BLE stopped working.

It's not clear why that delay is even needed but increasing the delay fixed the problem for now.

A few additional critical-sections were added just in case but don't seem to make any difference.

This also fixes memory allocation problems.

Closes #114 
