### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
       - name: build (embassy_dhcp)
         run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
       - name: build (embassy_access_point)
-        run: cd examples-esp32c2 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=embassy_access_point --features=async,wifi,embassy-net
       - name: build (static_ip)
-        run: cd examples-esp32c2 && cargo build --release --example=static_ip --features=wifi
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
 
   esp32c3:
     runs-on: ubuntu-latest
@@ -113,9 +113,9 @@ jobs:
       - name: build (embassy_dhcp)
         run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
       - name: build (embassy_access_point)
-        run: cd examples-esp32c3 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=embassy_access_point --features=async,wifi,embassy-net
       - name: build (static_ip)
-        run: cd examples-esp32c3 && cargo build --release --example=static_ip --features=wifi
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
 
   esp32c6:
     runs-on: ubuntu-latest
@@ -139,9 +139,9 @@ jobs:
       - name: build (embassy_dhcp)
         run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
       - name: build (embassy_access_point)
-        run: cd examples-esp32c6 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=embassy_access_point --features=async,wifi,embassy-net
       - name: build (static_ip)
-        run: cd examples-esp32c6 && cargo build --release --example=static_ip --features=wifi
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
 
   esp32s2:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,19 @@ jobs:
       - name: build (async-ble)
         run: cd examples-esp32 && cargo build --release --example=async_ble --features=async,ble
       - name: build (dhcp)
-        run: cd examples-esp32 && cargo build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32 && cargo build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32 && cargo build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32 && cargo build --release --example=static_ip --features=wifi
       - name: build (esp_now)
         run: cd examples-esp32 && cargo build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
         run: cd examples-esp32 && cargo build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32 && cargo build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32 && cargo build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32 && cargo build --release --example=static_ip --features=wifi
 
   esp32c2:
     runs-on: ubuntu-latest
@@ -58,24 +62,28 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: nightly-2023-03-09
+          toolchain: nightly-2023-05-16
           components: rust-src
       - uses: Swatinem/rust-cache@v1
 
       - name: build (ble)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=ble --features=ble
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=ble --features=ble
       - name: build (async-ble)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=async_ble --features=async,ble
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=async_ble --features=async,ble
       - name: build (dhcp)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
       - name: build (esp_now)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=esp_now --features=esp-now
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=embassy_esp_now --features=async,esp-now
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32c2 && cargo +nightly-2023-03-09 build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32c2 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32c2 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32c2 && cargo build --release --example=static_ip --features=wifi
 
   esp32c3:
     runs-on: ubuntu-latest
@@ -84,26 +92,30 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf
-          toolchain: nightly-2023-03-09
+          toolchain: nightly-2023-05-16
           components: rust-src
       - uses: Swatinem/rust-cache@v1
 
       - name: build (ble)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=ble --features=ble
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=ble --features=ble
       - name: build (async-ble)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=async_ble --features=async,ble
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=async_ble --features=async,ble
       - name: build (coex)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=coex --features=embedded-svc,wifi,ble
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=coex --features=wifi,ble
       - name: build (dhcp)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
       - name: build (esp_now)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=esp_now --features=esp-now
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=embassy_esp_now --features=async,esp-now
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32c3 && cargo +nightly-2023-03-09 build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32c3 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32c3 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32c3 && cargo build --release --example=static_ip --features=wifi
 
   esp32c6:
     runs-on: ubuntu-latest
@@ -112,20 +124,24 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imac-unknown-none-elf
-          toolchain: nightly-2023-03-09
+          toolchain: nightly-2023-05-16
           components: rust-src
       - uses: Swatinem/rust-cache@v1
 
       - name: build (dhcp)
-        run: cd examples-esp32c6 && cargo +nightly-2023-03-09 build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32c6 && cargo +nightly-2023-03-09 build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=static_ip --features=wifi
       - name: build (esp_now)
-        run: cd examples-esp32c6 && cargo +nightly-2023-03-09 build --release --example=esp_now --features=esp-now
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
-        run: cd examples-esp32c6 && cargo +nightly-2023-03-09 build --release --example=embassy_esp_now --features=async,esp-now
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32c6 && cargo +nightly-2023-03-09 build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32c6 && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32c6 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32c6 && cargo build --release --example=static_ip --features=wifi
 
   esp32s2:
     runs-on: ubuntu-latest
@@ -139,15 +155,19 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: build (dhcp)
-        run: cd examples-esp32s2 && cargo build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32s2 && cargo build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32s2 && cargo build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32s2 && cargo build --release --example=static_ip --features=wifi
       - name: build (esp_now)
         run: cd examples-esp32s2 && cargo build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
         run: cd examples-esp32s2 && cargo build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32s2 && cargo build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32s2 && cargo build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32s2 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32s2 && cargo build --release --example=static_ip --features=wifi
 
   esp32s3:
     runs-on: ubuntu-latest
@@ -165,14 +185,18 @@ jobs:
       - name: build (async-ble)
         run: cd examples-esp32s3 && cargo build --release --example=async_ble --features=async,ble
       - name: build (coex)
-        run: cd examples-esp32s3 && cargo build --release --example=coex --features=embedded-svc,wifi,ble
+        run: cd examples-esp32s3 && cargo build --release --example=coex --features=wifi,ble
       - name: build (dhcp)
-        run: cd examples-esp32s3 && cargo build --release --example=dhcp --features=embedded-svc,wifi
+        run: cd examples-esp32s3 && cargo build --release --example=dhcp --features=wifi
       - name: build (static_ip)
-        run: cd examples-esp32s3 && cargo build --release --example=static_ip --features=embedded-svc,wifi
+        run: cd examples-esp32s3 && cargo build --release --example=static_ip --features=wifi
       - name: build (esp_now)
         run: cd examples-esp32s3 && cargo build --release --example=esp_now --features=esp-now
       - name: build (embassy_esp_now)
         run: cd examples-esp32s3 && cargo build --release --example=embassy_esp_now --features=async,esp-now
       - name: build (embassy_dhcp)
-        run: cd examples-esp32s3 && cargo build --release --example=embassy_dhcp --features=async,embedded-svc,wifi,embassy-net
+        run: cd examples-esp32s3 && cargo build --release --example=embassy_dhcp --features=async,wifi,embassy-net
+      - name: build (embassy_access_point)
+        run: cd examples-esp32s3 && cargo build --release --example=embassy_access_point --features=async,wifi,embassy-net
+      - name: build (static_ip)
+        run: cd examples-esp32s3 && cargo build --release --example=static_ip --features=wifi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ esp32s2-hal = { version = "0.9.0", features = [ "rt" ] }
 esp32c3 = { version = "0.14.0",  features = ["critical-section"] }
 esp32c2 = { version = "0.11.0",  features = ["critical-section"] }
 esp32c6 = { version = "0.4.0",  features = ["critical-section"] }
-smoltcp = { version = "0.9.1", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "1.1.1"
 atomic-polyfill = "1.0.1"
 log = "0.4.17"
@@ -52,9 +52,9 @@ num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { version = "0.2.0" }
 embassy-futures = { version = "0.1.0" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
-embassy-net-driver = { git = "https://github.com/embassy-rs/embassy", rev = "fb27594" }
+embassy-net-driver = { version = "0.1.0" }
 
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "b82f1e7009bef7e32f0918be5b186188aa5e7109", features = ["macros"] }
 embassy-executor = { version = "0.2.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] }
 embassy-time = { version = "0.1.1", features = ["nightly"] }

--- a/README.md
+++ b/README.md
@@ -116,15 +116,21 @@ To build these ensure you are in the `examples-esp32XXX` directory matching your
 
 ## Features
 
-| Feature      | Meaning                                                                                             |
-| ------------ | --------------------------------------------------------------------------------------------------- |
-| wifi-logs    | logs the WiFi logs from the driver at log level info                                                |
-| dump-packets | dumps packet info at log level info                                                                 |
-| utils        | Provide utilities for smoltcp initialization, this is a default feature                             |
-| embedded-svc | Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` feature |
-| ble          | Enable BLE support                                                                                  |
-| wifi         | Enable WiFi support                                                                                 |
-| esp-now      | Enable esp-now support                                                                              |
+| Feature        | Meaning                                                                                             |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| wifi-logs      | logs the WiFi logs from the driver at log level info                                                |
+| dump-packets   | dumps packet info at log level info                                                                 |
+| utils          | Provide utilities for smoltcp initialization, this is a default feature                             |
+| embedded-svc   | Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` feature |
+| ble            | Enable BLE support                                                                                  |
+| wifi           | Enable WiFi support                                                                                 |
+| esp-now        | Enable esp-now support                                                                              |
+| coex           | Enable coex support                                                                                 |
+| mtu-XXX        | Set MTU to XXX, XXX can be 746, 1492, 1500, 1514. Defaults to 1492                                  |
+| big-heap       | Reserve more heap memory for the drivers                                                            |
+| ipv6           | IPv6 support                                                                                        |
+| phy-enable-usb | See _Using Serial-JTAG_ below                                                                       |
+| ps-min-modem   | Enable modem sleep                                                                                  |
 
 When using the `dump-packets` feauture you can use the extcap in `extras/esp-wifishark` to analyze the frames in Wireshark.
 For more information see [extras/esp-wifishark/README.md](extras/esp-wifishark/README.md)

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -31,7 +31,6 @@ num-traits = { workspace = true, default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { workspace = true, optional = true }
 embassy-futures = { workspace = true, optional = true }
-embassy-net = { workspace = true, optional = true }
 embassy-net-driver = { workspace = true, optional = true }
 
 [features]
@@ -58,7 +57,7 @@ async = [
   "esp32s3-hal?/embassy",
 ]
 
-embassy-net = ["dep:embassy-net", "dep:embassy-net-driver", "async"]
+embassy-net = ["dep:embassy-net-driver", "async"]
 
 # misc features
 coex = []
@@ -77,4 +76,4 @@ mtu-1514 = []
 mtu-1500 = []
 mtu-1492 = []
 mtu-746 = []
-ipv6 = ["smoltcp?/proto-ipv6", "embassy-net?/proto-ipv6"]
+ipv6 = ["smoltcp?/proto-ipv6"]

--- a/examples-esp32/examples/embassy_access_point.rs
+++ b/examples-esp32/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32/examples/embassy_dhcp.rs
+++ b/examples-esp32/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");

--- a/examples-esp32c2/examples/embassy_access_point.rs
+++ b/examples-esp32c2/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32c2/examples/embassy_dhcp.rs
+++ b/examples-esp32c2/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");

--- a/examples-esp32c3/examples/embassy_access_point.rs
+++ b/examples-esp32c3/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32c3/examples/embassy_dhcp.rs
+++ b/examples-esp32c3/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");

--- a/examples-esp32c6/examples/embassy_access_point.rs
+++ b/examples-esp32c6/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32c6/examples/embassy_dhcp.rs
+++ b/examples-esp32c6/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");

--- a/examples-esp32s2/examples/embassy_access_point.rs
+++ b/examples-esp32s2/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32s2/examples/embassy_dhcp.rs
+++ b/examples-esp32s2/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");

--- a/examples-esp32s3/examples/embassy_access_point.rs
+++ b/examples-esp32s3/examples/embassy_access_point.rs
@@ -6,8 +6,9 @@
 
 use embassy_executor::_export::StaticCell;
 use embassy_net::tcp::TcpSocket;
+use embassy_net::ConfigV4;
 use embassy_net::{
-    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfig,
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
 };
 use examples_util::hal;
 
@@ -61,11 +62,13 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Static(StaticConfig {
-        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
-        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
-        dns_servers: Default::default(),
-    });
+    let config = Config {
+        ipv4: ConfigV4::Static(StaticConfigV4 {
+            address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+            gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+            dns_servers: Default::default(),
+        }),
+    };
 
     let seed = 1234; // very random, very secure seed
 
@@ -131,7 +134,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
     println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
 
     let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
-    socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+    socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
     loop {
         println!("Wait for connection...");
         let r = socket

--- a/examples-esp32s3/examples/embassy_dhcp.rs
+++ b/examples-esp32s3/examples/embassy_dhcp.rs
@@ -63,7 +63,7 @@ fn main() -> ! {
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
     embassy::init(&clocks, timer_group0.timer0);
 
-    let config = Config::Dhcp(Default::default());
+    let config = Config::dhcpv4(Default::default());
 
     let seed = 1234; // very random, very secure seed
 
@@ -138,7 +138,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
     println!("Waiting to get IP address...");
     loop {
-        if let Some(config) = stack.config() {
+        if let Some(config) = stack.config_v4() {
             println!("Got IP: {}", config.address);
             break;
         }
@@ -150,7 +150,7 @@ async fn task(stack: &'static Stack<WifiDevice<'static>>) {
 
         let mut socket = TcpSocket::new(&stack, &mut rx_buffer, &mut tx_buffer);
 
-        socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
         let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
         println!("connecting...");


### PR DESCRIPTION
- Update README.md to mention more feature flags
- embassy-net is not a direct dependency anymore
- Update CI to check more examples / use a later nightly
- Update to smoltcp 0.10.0
- Use published embassy-net / embassy-net-driver
