### PR TITLE
Add DNS query interface to WifiStack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ esp32s2-hal = { version = "0.10.0", features = [ "rt" ] }
 esp32c3 = { version = "0.15.0",  features = ["critical-section"] }
 esp32c2 = { version = "0.12.0",  features = ["critical-section"] }
 esp32c6 = { version = "0.5.0",  features = ["critical-section"] }
-smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "proto-dns", "socket-tcp", "socket-icmp", "socket-udp", "socket-dns", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "1.1.1"
 atomic-polyfill = "1.0.1"
 log = "0.4.17"

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -276,7 +276,7 @@ impl<'a> WifiStack<'a> {
         }
     }
 
-    pub fn is_dns_configured() -> bool {
+    pub fn is_dns_configured(&self) -> bool {
         self.dns_socket_handle.borrow().is_some()
     }
 

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -302,6 +302,21 @@ impl<'a> WifiStack<'a> {
     ) -> Result<heapless::Vec<IpAddress, 1>, WifiStackError> {
         use smoltcp::socket::dns;
 
+        match query_type { // check if name is already an IP
+            DnsQueryType::A => {
+                if let Ok(ip) = name.parse::<Ipv4Address>() {
+                    return Ok([ip.into()].into_iter().collect());
+                }
+            }
+            #[cfg(feature = "ipv6")]
+            DnsQueryType::Aaaa => {
+                if let Ok(ip) = name.parse::<smoltcp::wire::Ipv6Address>() {
+                    return Ok([ip.into()].into_iter().collect());
+                }
+            }
+            _ => {}
+        }
+
         let Some(dns_handle) = *self.dns_socket_handle.borrow() else {
             return Err(WifiStackError::DnsNotConfigured);
         };


### PR DESCRIPTION
Follow up to #212. Adds three new DNS-related functions to WifiStack in wifi_interface.rs:
- **is_dns_configured**: Returns true if a DNS Socket is in the socket storage and ready for DNS queries
- **configure_dns**: Configures a new socket (overrides it if already present) with the specified DNS server and DNS query storage as required by smoltcp.
- **dns_query**: Performs a sync DNS query of the specified hostname and returns a result with an IpAddress. If name is already an IP address, it gets parsed and returned directly.

I tested my code with an example sketch on my esp32-s3-devkit-c board with multiple DNS queries followed by a GET HTTP request. It would be nice to update the examples also if this PR is approved.