### PR TITLE
Refactor TCP socket read impl to handle correctly EOF and no data

### DIFF
--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -633,7 +633,7 @@ impl<'s, 'n: 's> Read for Socket<'s, 'n> {
                 match socket.recv_slice(buf) {
                     Ok(0) => continue, // no data
                     Ok(n) => return Ok(n),
-                    Err(RecvError::Finished) => return Ok(0), // eof
+                    Err(RecvError::Finished) => return Err(IoError::SocketClosed), // eof
                     Err(RecvError::InvalidState) => return Err(IoError::TcpRecvError)
                 }
             }

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -602,7 +602,7 @@ impl<'s, 'n: 's> Drop for Socket<'s, 'n> {
 pub enum IoError {
     SocketClosed,
     MultiCastError(smoltcp::iface::MulticastError),
-    TcpRecvError(smoltcp::socket::tcp::RecvError),
+    TcpRecvError,
     UdpRecvError(smoltcp::socket::udp::RecvError),
     TcpSendError(smoltcp::socket::tcp::SendError),
     UdpSendError(smoltcp::socket::udp::SendError),
@@ -623,52 +623,20 @@ impl<'s, 'n: 's> Io for Socket<'s, 'n> {
 
 impl<'s, 'n: 's> Read for Socket<'s, 'n> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        loop {
-            self.network.with_mut(|interface, device, sockets| {
-                interface.poll(
-                    Instant::from_millis((self.network.current_millis_fn)() as i64),
-                    device,
-                    sockets,
-                )
-            });
+        self.network.with_mut(|interface, device, sockets| {
+            use smoltcp::socket::tcp::RecvError;
 
-            let (may_recv, is_open, can_recv) =
-                self.network.with_mut(|_interface, _device, sockets| {
-                    let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
+            loop {
+                interface.poll(timestamp(), device, sockets);
+                let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
 
-                    (socket.may_recv(), socket.is_open(), socket.can_recv())
-                });
-            if may_recv {
-                break;
+                match socket.recv_slice(buf) {
+                    Ok(0) => continue, // no data
+                    Ok(n) => return Ok(n),
+                    Err(RecvError::Finished) => return Ok(0), // eof
+                    Err(RecvError::InvalidState) => return Err(IoError::TcpRecvError)
+                }
             }
-
-            if !is_open {
-                return Err(IoError::SocketClosed);
-            }
-
-            if !can_recv {
-                return Err(IoError::SocketClosed);
-            }
-        }
-
-        loop {
-            let res = self.network.with_mut(|interface, device, sockets| {
-                interface.poll(
-                    Instant::from_millis((self.network.current_millis_fn)() as i64),
-                    device,
-                    sockets,
-                )
-            });
-
-            if let false = res {
-                break;
-            }
-        }
-
-        self.network.with_mut(|_interface, _device, sockets| {
-            let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
-
-            socket.recv_slice(buf).map_err(|e| IoError::TcpRecvError(e))
         })
     }
 }


### PR DESCRIPTION
I noticed that the read implementation of the TCP Socket located in wifi_interface.rs is incorrect. When I was trying to use the embedded_tls package to perform HTTPS requests using esp-wifi I noticed that the TLSConnection could not perform handshake and always returns an IoError.

It seems that the current read implementation does not check if there is data available. Indeed, the recv_slice on smoltcp TCP Socket returns `Ok(0)` when there is no data available, and `RecvError::Finished` when the reading half is closed, [take a look at the smoltcp docs](https://docs.rs/smoltcp/0.10.0/smoltcp/socket/tcp/struct.Socket.html#method.recv). The issue is that an `Ok(0)` *[no data]* returned by the WifiStack TCP Socket read function can be interpreted as an **EOF** and thus trigger some kind of IO Error, whereas the socket is fine and is just waiting for data.

Furthermore, the recv function in smoltcp TCP Socket checks whether the reading half is open, which reduces a lot the code for the read implementation.
https://github.com/smoltcp-rs/smoltcp/blob/fa7fd3c321b8a3bbe1a8a4ee2ee5dc1b63231d6b/src/socket/tcp.rs#L1092C1-L1104C6

**PS**: Should read return IoError::TcpRecvError or IoError::SocketClosed ?