### PR TITLE
Clear state on stop

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1462,6 +1462,8 @@ mod asynch {
             embedded_svc::wifi::Wifi::stop(self)?;
             WifiEventFuture::new(event).await;
 
+            unsafe { WIFI_STATE = -1 };
+
             Ok(())
         }
 


### PR DESCRIPTION
Part of issue #211, this PR allows restarting a stopped WifiController. After stopping, the `WIFI_STATE` variable holds either `ApStop` or `StaStop`, and these values were considered by `is_started` as started. This prevents, in applications that follow the examples' structure, restarting wifi controllers.

The correct solution would be resolving #210 but just this addition is good enough for now.