### PR TITLE
fix log_timestamp value

### DIFF
--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -1579,7 +1579,7 @@ pub unsafe extern "C" fn log_writev(
  *
  ****************************************************************************/
 pub unsafe extern "C" fn log_timestamp() -> u32 {
-    (crate::timer::get_systimer_count() / crate::timer::TICKS_PER_SECOND / 1_000) as u32
+    (crate::timer::get_systimer_count() / (crate::timer::TICKS_PER_SECOND / 1_000)) as u32
 }
 
 /****************************************************************************


### PR DESCRIPTION
The divider should be applied only on the TICKS_PER_SECOND, rather than on the whole systimer count, to get the proper value in millis