### PR TITLE
Enable wifi/bt power domain

### DIFF
--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -16,6 +16,20 @@ static mut S_IS_PHY_REG_STORED: bool = false;
 static mut PHY_ACCESS_REF: AtomicU32 = AtomicU32::new(0);
 static mut PHY_CLOCK_ENABLE_REF: AtomicU32 = AtomicU32::new(0);
 
+pub(crate) fn enable_wifi_power_domain() {
+    unsafe {
+        let rtc_cntl = &*crate::hal::peripherals::RTC_CNTL::ptr();
+
+        rtc_cntl
+            .dig_pwc
+            .modify(|_, w| w.wifi_force_pd().clear_bit());
+
+        rtc_cntl
+            .dig_iso
+            .modify(|_, w| w.wifi_force_iso().clear_bit());
+    }
+}
+
 pub(crate) fn phy_mem_init() {
     unsafe {
         G_PHY_DIGITAL_REGS_MEM = SOC_PHY_DIG_REGS_MEM.as_ptr() as *mut u32;

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -15,6 +15,11 @@ static mut G_PHY_DIGITAL_REGS_MEM: *mut u32 = core::ptr::null_mut();
 static mut S_IS_PHY_REG_STORED: bool = false;
 static mut PHY_ACCESS_REF: AtomicU32 = AtomicU32::new(0);
 
+pub(crate) fn enable_wifi_power_domain() {
+    // In esp-idf, neither SOC_PM_SUPPORT_MODEM_PD or SOC_PM_SUPPORT_WIFI_PD are defined,
+    // which makes `esp_wifi_bt_power_domain_on` a no-op.
+}
+
 pub(crate) fn phy_mem_init() {
     unsafe {
         G_PHY_DIGITAL_REGS_MEM = SOC_PHY_DIG_REGS_MEM.as_ptr() as *mut u32;

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -15,6 +15,11 @@ static mut G_PHY_DIGITAL_REGS_MEM: *mut u32 = core::ptr::null_mut();
 static mut S_IS_PHY_REG_STORED: bool = false;
 static mut PHY_ACCESS_REF: AtomicU32 = AtomicU32::new(0);
 
+pub(crate) fn enable_wifi_power_domain() {
+    // In esp-idf, SOC_PMU_SUPPORTED is set which makes `esp_wifi_bt_power_domain_on`
+    // a no-op.
+}
+
 pub(crate) fn phy_mem_init() {
     unsafe {
         G_PHY_DIGITAL_REGS_MEM = SOC_PHY_DIG_REGS_MEM.as_ptr() as *mut u32;

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -16,6 +16,46 @@ static mut S_IS_PHY_REG_STORED: bool = false;
 static mut PHY_ACCESS_REF: AtomicU32 = AtomicU32::new(0);
 static mut PHY_CLOCK_ENABLE_REF: AtomicU32 = AtomicU32::new(0);
 
+pub(crate) fn enable_wifi_power_domain() {
+    // FIXME: commented code depends on the next esp-hal release that contains
+    // https://github.com/esp-rs/esp-hal/pull/697
+
+    // const DPORT_WIFIBB_RST: u32 = 1 << 0;
+    // const DPORT_FE_RST: u32 = 1 << 1;
+    // const DPORT_WIFIMAC_RST: u32 = 1 << 2;
+    // const DPORT_BTBB_RST: u32 = 1 << 3;
+    // const DPORT_BTMAC_RST: u32 = 1 << 4;
+    // const DPORT_RW_BTMAC_RST: u32 = 1 << 9;
+
+    // const MODEM_RESET_FIELD_WHEN_PU: u32 = DPORT_WIFIBB_RST
+    //     | DPORT_FE_RST
+    //     | DPORT_WIFIMAC_RST
+    //     | DPORT_BTBB_RST
+    //     | DPORT_BTMAC_RST
+    //     | DPORT_RW_BTMAC_RST;
+
+    unsafe {
+        let rtc_cntl = &*crate::hal::peripherals::RTC_CNTL::ptr();
+
+        // let syscon = &*crate::hal::peripherals::SYSCON::ptr();
+
+        rtc_cntl
+            .dig_pwc
+            .modify(|_, w| w.wifi_force_pd().clear_bit());
+
+        // syscon
+        //     .wifi_rst_en
+        //     .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
+        // syscon
+        //     .wifi_rst_en
+        //     .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
+
+        rtc_cntl
+            .dig_iso
+            .modify(|_, w| w.wifi_force_iso().clear_bit());
+    }
+}
+
 pub(crate) fn phy_mem_init() {
     unsafe {
         G_PHY_DIGITAL_REGS_MEM = SOC_PHY_DIG_REGS_MEM.as_ptr() as *mut u32;

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -20,6 +20,46 @@ pub(crate) fn phy_mem_init() {
     }
 }
 
+pub(crate) fn enable_wifi_power_domain() {
+    const SYSTEM_WIFIBB_RST: u32 = 1 << 0;
+    const SYSTEM_FE_RST: u32 = 1 << 1;
+    const SYSTEM_WIFIMAC_RST: u32 = 1 << 2;
+    const SYSTEM_BTBB_RST: u32 = 1 << 3; /* Bluetooth Baseband */
+    const SYSTEM_BTMAC_RST: u32 = 1 << 4; /* deprecated */
+    const SYSTEM_RW_BTMAC_RST: u32 = 1 << 9; /* Bluetooth MAC */
+    const SYSTEM_RW_BTMAC_REG_RST: u32 = 1 << 11; /* Bluetooth MAC Regsiters */
+    const SYSTEM_BTBB_REG_RST: u32 = 1 << 13; /* Bluetooth Baseband Registers */
+
+    const MODEM_RESET_FIELD_WHEN_PU: u32 = SYSTEM_WIFIBB_RST
+        | SYSTEM_FE_RST
+        | SYSTEM_WIFIMAC_RST
+        | SYSTEM_BTBB_RST
+        | SYSTEM_BTMAC_RST
+        | SYSTEM_RW_BTMAC_RST
+        | SYSTEM_RW_BTMAC_REG_RST
+        | SYSTEM_BTBB_REG_RST;
+
+    unsafe {
+        let rtc_cntl = &*crate::hal::peripherals::RTC_CNTL::ptr();
+        let syscon = &*crate::hal::peripherals::APB_CTRL::ptr();
+
+        rtc_cntl
+            .dig_pwc
+            .modify(|_, w| w.wifi_force_pd().clear_bit());
+
+        syscon
+            .wifi_rst_en
+            .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
+        syscon
+            .wifi_rst_en
+            .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
+
+        rtc_cntl
+            .dig_iso
+            .modify(|_, w| w.wifi_force_iso().clear_bit());
+    }
+}
+
 pub(crate) unsafe fn phy_enable() {
     let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
     if count == 0 {

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -240,6 +240,8 @@ pub fn initialize(
         rom_ets_update_cpu_frequency(240); // we know it's 240MHz because of the check above
     }
 
+    crate::common_adapter::chip_specific::enable_wifi_power_domain();
+
     init_heap();
     phy_mem_init();
     init_radio_clock_control(radio_clocks);


### PR DESCRIPTION
Necessary to unbreak wifi after https://github.com/esp-rs/esp-hal/pull/660 - the setup code running after RTC initialization now disables Wifi clocks, as done in esp-idf.

Blocked on https://github.com/esp-rs/esp-hal/pull/697