### PR TITLE
Wait for esp now send callback to be called after sending

### DIFF
--- a/examples-esp32/examples/embassy_esp_now.rs
+++ b/examples-esp32/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32/examples/esp_now.rs
+++ b/examples-esp32/examples/esp_now.rs
@@ -54,14 +54,16 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }

--- a/examples-esp32c2/examples/embassy_esp_now.rs
+++ b/examples-esp32c2/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32c2/examples/esp_now.rs
+++ b/examples-esp32c2/examples/esp_now.rs
@@ -54,14 +54,16 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }

--- a/examples-esp32c3/examples/embassy_esp_now.rs
+++ b/examples-esp32c3/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status);
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32c3/examples/esp_now.rs
+++ b/examples-esp32c3/examples/esp_now.rs
@@ -54,8 +54,7 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                let waiter = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
-                let status = waiter.wait();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
                 println!("Send hello to peer status: {:?}", status);
             }
         }

--- a/examples-esp32c3/examples/esp_now.rs
+++ b/examples-esp32c3/examples/esp_now.rs
@@ -54,14 +54,17 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let waiter = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = waiter.wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }

--- a/examples-esp32c6/examples/embassy_esp_now.rs
+++ b/examples-esp32c6/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32c6/examples/esp_now.rs
+++ b/examples-esp32c6/examples/esp_now.rs
@@ -54,14 +54,16 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }

--- a/examples-esp32s2/examples/embassy_esp_now.rs
+++ b/examples-esp32s2/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32s2/examples/esp_now.rs
+++ b/examples-esp32s2/examples/esp_now.rs
@@ -54,14 +54,16 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }

--- a/examples-esp32s3/examples/embassy_esp_now.rs
+++ b/examples-esp32s3/examples/embassy_esp_now.rs
@@ -38,7 +38,8 @@ async fn run(mut esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").unwrap().await;
+                println!("Send hello to peer status: {:?}", status);
             }
         })
         .await;
@@ -46,7 +47,8 @@ async fn run(mut esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").unwrap().await;
+                println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),
         }

--- a/examples-esp32s3/examples/esp_now.rs
+++ b/examples-esp32s3/examples/esp_now.rs
@@ -54,14 +54,16 @@ fn main() -> ! {
                         })
                         .unwrap();
                 }
-                esp_now.send(&r.info.src_address, b"Hello Peer").unwrap();
+                let status = esp_now.send(&r.info.src_address, b"Hello Peer").unwrap().wait();
+                println!("Send hello to peer status: {:?}", status);
             }
         }
 
         if current_millis() >= next_send_time {
             next_send_time = current_millis() + 5 * 1000;
             println!("Send");
-            esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap();
+            let status = esp_now.send(&BROADCAST_ADDRESS, b"0123456789").unwrap().wait();
+            println!("Send broadcast status: {:?}", status)
         }
     }
 }


### PR DESCRIPTION
This fixes #229. However, I think there might be a better way rather than a busy loop for the sync implementation. 

Also, I noticed the send time (time between sending data and callback is called) after the fix is way too high. 

Currently it takes about 10ms for a successful sending (measured with [this example](https://github.com/M4tsuri/esp-wifi/blob/fix_esp_now_send/examples-esp32c3/examples/embassy_esp_now_bench.rs)):

![image](https://github.com/esp-rs/esp-wifi/assets/51822222/b519aff8-67b8-4dbe-a2bb-67a91fcef0b7)

While it only takes about 1ms in [my C implementation](https://github.com/M4tsuri/EspNowBench):

![image](https://github.com/esp-rs/esp-wifi/assets/51822222/7c2a2ba7-6b95-4991-9007-92dc60c937c9)


This PR is ready until these problems are settled:

- [x] Find a better way for the sync implementation
- [x] Find out the cause of high send time and try to fix it