### PR TITLE
Configurable tuning parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { version = "0.2.0" }
 embassy-futures = { version = "0.1.0" }
 embassy-net-driver = { version = "0.1.0" }
+toml-cfg = "0.1.3"
 
 embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "b82f1e7009bef7e32f0918be5b186188aa5e7109", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ For more information see [extras/esp-wifishark/README.md](extras/esp-wifishark/R
 > 
 > Don't use this feature if your are _not_ using Serial-JTAG since it might reduce WiFi performance.
 
+### Tuning
+
+The defaults used by `esp-wifi` and the examples are rather conservative. It is possible to change a few of the important settings.
+
+See [Tuning](docs/tuning.md) for details
+
 ### What works?
 
 - scanning for WiFi access points

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,47 @@
+# Tuning the configuration
+
+You can change a few of the default settings used. Please keep in mind that it's almost always a tradeoff between memory usage and performance.
+It's easy to decrease performance by using unfortunate settings or even break the application or making it less stable.
+
+So you should test every change very carefully.
+
+Be aware that settings which work fine on one ESP32 model might not work at all on other. Also, settings should be adjusted according to your application's needs.
+
+## Create a configuration
+
+We use [toml-cfg](https://crates.io/crates/toml-cfg) for the build time configuration
+
+You need to add a `cfg.toml` file in the root of your binary crate. When using a _Cargo Workspace_ you should put the file in the root of the workspace directory.
+
+A configuration file can look like this:
+```toml
+[esp-wifi]
+rx_queue_size = 15
+tx_queue_size = 3
+static_rx_buf_num = 10
+dynamic_rx_buf_num = 16
+ampdu_rx_enable = 0
+ampdu_tx_enable = 0
+rx_ba_win = 32
+max_burst_size = 6
+```
+
+You can set the following settings
+|Key|Description|
+|-|-|
+|rx_queue_size|Size of the RX queue in frames|
+|tx_queue_size|Size of the TX queue in frames|
+|max_burst_size|See [documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)|
+|static_rx_buf_num|WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|dynamic_rx_buf_num|WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|static_tx_buf_num|WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|dynamic_tx_buf_num|WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|ampdu_rx_enable|WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|ampdu_rx_enable|WiFi AMPDU RX feature enable flag. (0 or 1) See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|ampdu_tx_enable|WiFi AMPDU TX feature enable flag. (0 or 1) See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|amsdu_tx_enable|WiFi AMSDU TX feature enable flag. (0 or 1) See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|rx_ba_win|WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+
+## Globally disable logging
+
+`esp-wifi` contains a lot of trace-level logging statements. For maximum performance you might want to disable logging via a feature flag of the `log` crate. See [documentation](https://docs.rs/log/0.4.19/log/#compile-time-filters). You should set it to `release_max_level_off`

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -32,6 +32,7 @@ esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { workspace = true, optional = true }
 embassy-futures = { workspace = true, optional = true }
 embassy-net-driver = { workspace = true, optional = true }
+toml-cfg.workspace = true
 
 [features]
 default = [ "utils", "mtu-1492" ]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -104,6 +104,33 @@ const HEAP_SIZE: usize = 72 * 1024;
 #[cfg(all(coex, feature = "big-heap"))]
 const HEAP_SIZE: usize = 110 * 1024;
 
+#[derive(Debug)]
+#[toml_cfg::toml_config]
+struct Config {
+    #[default(5)]
+    rx_queue_size: usize,
+    #[default(3)]
+    tx_queue_size: usize,
+    #[default(10)]
+    static_rx_buf_num: usize,
+    #[default(32)]
+    dynamic_rx_buf_num: usize,
+    #[default(0)]
+    static_tx_buf_num: usize,
+    #[default(32)]
+    dynamic_tx_buf_num: usize,
+    #[default(0)]
+    ampdu_rx_enable: usize,
+    #[default(0)]
+    ampdu_tx_enable: usize,
+    #[default(0)]
+    amsdu_tx_enable: usize,
+    #[default(6)]
+    rx_ba_win: usize,
+    #[default(1)]
+    max_burst_size: usize,
+}
+
 #[cfg_attr(esp32, link_section = ".dram2_uninit")]
 static mut HEAP_DATA: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
 
@@ -232,6 +259,8 @@ pub fn initialize(
 
         rom_ets_update_cpu_frequency(240); // we know it's 240MHz because of the check above
     }
+
+    log::info!("esp-wifi configuration {:?}", crate::CONFIG);
 
     crate::common_adapter::chip_specific::enable_wifi_power_domain();
 


### PR DESCRIPTION
This adds the ability to fine-tune some parameters.

We currently use some sane defaults for a few things. However for best performance it's needed to allow changing those.
Going with Cargo features won't be a good idea so this introduces cfg-toml for configuration. I think in future we should also make the WIFI-HEAP and MTU configurable via this mechanism. But that is something for another PR.

Testing this on ESP32-C3 (suggestion). (Note: the exact values won't work the same or at all for other chips)

- make your computer a hotspot
- have a file named "testfile" (around 1MB should be fine) in some directory and run `devserver --address <LOCALIP>:80` in that directory

Change the `dns.rs` example to download from your computer and extremely bump some buffers
```rust

... code after printing "Start busy loop on main"


let mut rx_buffer = [0u8; 1536 * 64];
    let mut tx_buffer = [0u8; 1536 * 1];
    let mut socket = wifi_stack.get_socket(&mut rx_buffer, &mut tx_buffer);

    loop {
        println!("Making HTTP request");
        socket.work();

        socket
            .open(IpAddress::Ipv4(Ipv4Address::new(192, 168, 137, 1)), 80)
            .unwrap();

        socket
            .write(b"GET /testfile HTTP/1.0\r\nHost: 192.168.137.1\r\n\r\n")
            .unwrap();
        socket.flush().unwrap();

        let wait_end = current_millis() + 20 * 1000;
        let mut bytes = 0;
        let t1 = current_millis();
        let mut buffer = [0u8; 1024 * 32];
        loop {
            if let Ok(len) = socket.read(&mut buffer) {
                //println!("{len}");
                bytes += len;
            } else {
                break;
            }

            if current_millis() > wait_end {
                println!("Timeout");
                break;
            }
        }
        let t2 = current_millis();

        println!();

        socket.disconnect();

        let speed = bytes as u64 * 1000 / (t2 as u64 - t1 as u64);
        println!("Bytes {}, millis {}, B/s {}", bytes, t2 - t1, speed);

        let wait_end = current_millis() + 5 * 1000;
        while current_millis() < wait_end {
            socket.work();
        }
    }

```

Change the IP address to match your setting. Set SSID/PASSWORD to match your computer's hotspot.

Add this as `cfg.toml` in the root of the workspace:
```toml
[esp-wifi]
rx_queue_size = 20
tx_queue_size = 5
static_rx_buf_num = 32
dynamic_rx_buf_num = 16
ampdu_rx_enable = 1
ampdu_tx_enable = 1
rx_ba_win = 32
max_burst_size = 8
```

Run the example `cargo run --example dns --release --features "wifi"` and see the bytes/second.

Remove the `cfg.toml` and re-run ... you should see a difference.

Please note: The extreme buffer sizes etc. probably won't work as is for other chips. However it shows users can change the settings.
