### PR TITLE
Add more configuration options

### DIFF
--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -41,6 +41,11 @@ You can set the following settings
 |ampdu_tx_enable|WiFi AMPDU TX feature enable flag. (0 or 1) See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
 |amsdu_tx_enable|WiFi AMSDU TX feature enable flag. (0 or 1) See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
 |rx_ba_win|WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)|
+|country_code|Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)|
+|country_code_operating_class|If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)|
+|mtu|MTU, see [documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)|
+|heap_size|Size of the WiFi/BLE heap in bytes|
+|tick_rate_hz|Tick rate of the internal task scheduler in hertz.|
 
 ## Globally disable logging
 

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -35,7 +35,7 @@ embassy-net-driver = { workspace = true, optional = true }
 toml-cfg.workspace = true
 
 [features]
-default = [ "utils", "mtu-1492" ]
+default = [ "utils" ]
 
 # chip features
 esp32c3 = [ "esp32c3-hal", "dep:esp32c3", "esp-wifi-sys/esp32c3", "esp-hal-common/esp32c3" ]
@@ -73,8 +73,4 @@ phy-enable-usb = []
 ps-min-modem = []
 esp-now = [ "wifi" ]
 big-heap = []
-mtu-1514 = []
-mtu-1500 = []
-mtu-1492 = []
-mtu-746 = []
 ipv6 = ["smoltcp?/proto-ipv6"]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -90,24 +90,16 @@ pub fn current_millis() -> u64 {
 }
 
 #[allow(unused)]
-#[cfg(all(not(coex), not(feature = "big-heap")))]
+#[cfg(all(not(feature = "big-heap")))]
 const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
 
 #[allow(unused)]
-#[cfg(all(coex, not(feature = "big-heap")))]
-const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
-
-#[allow(unused)]
-#[cfg(all(not(coex), not(esp32s2), feature = "big-heap"))]
+#[cfg(all(not(esp32s2), feature = "big-heap"))]
 const DEFAULT_HEAP_SIZE: usize = 110 * 1024;
 
 #[allow(unused)]
-#[cfg(all(not(coex), esp32s2, feature = "big-heap"))]
+#[cfg(all(esp32s2, feature = "big-heap"))]
 const DEFAULT_HEAP_SIZE: usize = 72 * 1024;
-
-#[allow(unused)]
-#[cfg(all(coex, feature = "big-heap"))]
-const DEFAULT_HEAP_SIZE: usize = 110 * 1024;
 
 const HEAP_SIZE: usize = crate::CONFIG.heap_size;
 

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -89,20 +89,35 @@ pub fn current_millis() -> u64 {
     get_systimer_count() / (TICKS_PER_SECOND / 1000)
 }
 
+#[allow(unused)]
 #[cfg(all(not(coex), not(feature = "big-heap")))]
-const HEAP_SIZE: usize = 64 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
 
+#[allow(unused)]
 #[cfg(all(coex, not(feature = "big-heap")))]
-const HEAP_SIZE: usize = 64 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 64 * 1024;
 
+#[allow(unused)]
 #[cfg(all(not(coex), not(esp32s2), feature = "big-heap"))]
-const HEAP_SIZE: usize = 110 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 110 * 1024;
 
+#[allow(unused)]
 #[cfg(all(not(coex), esp32s2, feature = "big-heap"))]
-const HEAP_SIZE: usize = 72 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 72 * 1024;
 
+#[allow(unused)]
 #[cfg(all(coex, feature = "big-heap"))]
-const HEAP_SIZE: usize = 110 * 1024;
+const DEFAULT_HEAP_SIZE: usize = 110 * 1024;
+
+const HEAP_SIZE: usize = crate::CONFIG.heap_size;
+
+#[allow(unused)]
+#[cfg(debug_assertions)]
+const DEFAULT_TICK_RATE_HZ: u32 = 50;
+
+#[allow(unused)]
+#[cfg(not(debug_assertions))]
+const DEFAULT_TICK_RATE_HZ: u32 = 100;
 
 #[derive(Debug)]
 #[toml_cfg::toml_config]
@@ -129,6 +144,16 @@ struct Config {
     rx_ba_win: usize,
     #[default(1)]
     max_burst_size: usize,
+    #[default("CN")]
+    country_code: &'static str,
+    #[default(0)]
+    country_code_operating_class: u8,
+    #[default(1492)]
+    mtu: usize,
+    #[default(DEFAULT_HEAP_SIZE)]
+    heap_size: usize,
+    #[default(DEFAULT_TICK_RATE_HZ)]
+    tick_rate_hz: u32,
 }
 
 #[cfg_attr(esp32, link_section = ".dram2_uninit")]

--- a/esp-wifi/src/timer_esp32.rs
+++ b/esp-wifi/src/timer_esp32.rs
@@ -20,10 +20,7 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32c2.rs
+++ b/esp-wifi/src/timer_esp32c2.rs
@@ -15,10 +15,7 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32c3.rs
+++ b/esp-wifi/src/timer_esp32c3.rs
@@ -15,10 +15,7 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32c6.rs
+++ b/esp-wifi/src/timer_esp32c6.rs
@@ -15,10 +15,7 @@ pub const TICKS_PER_SECOND: u64 = 16_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0x000F_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32s2.rs
+++ b/esp-wifi/src/timer_esp32s2.rs
@@ -20,10 +20,7 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/timer_esp32s3.rs
+++ b/esp-wifi/src/timer_esp32s3.rs
@@ -18,10 +18,7 @@ pub const TICKS_PER_SECOND: u64 = 40_000_000;
 
 pub const COUNTER_BIT_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFF;
 
-#[cfg(debug_assertions)]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(50);
-#[cfg(not(debug_assertions))]
-const TIMER_DELAY: fugit::HertzU64 = fugit::HertzU64::from_raw(100);
+const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
 
 static TIMER1: Mutex<RefCell<Option<Timer<Timer0<TIMG1>>>>> = Mutex::new(RefCell::new(None));
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -40,14 +40,7 @@ use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
 
 const ETHERNET_FRAME_HEADER_SIZE: usize = 18;
 
-#[cfg(feature = "mtu-1514")]
-const MTU: usize = 1514;
-#[cfg(feature = "mtu-1500")]
-const MTU: usize = 1500;
-#[cfg(feature = "mtu-1492")]
-const MTU: usize = 1492;
-#[cfg(feature = "mtu-746")]
-const MTU: usize = 746;
+const MTU: usize = crate::CONFIG.mtu;
 
 #[cfg(esp32)]
 use esp32_hal as hal;
@@ -661,7 +654,13 @@ pub fn wifi_start() -> Result<(), WifiError> {
             crate::binary::include::wifi_ps_type_t_WIFI_PS_NONE
         ))?;
 
-        let cntry_code = [b'C', b'N', 0];
+        let mut cntry_code = [0u8; 3];
+        cntry_code[..crate::CONFIG.country_code.len()]
+            .copy_from_slice(crate::CONFIG.country_code.as_bytes());
+        if crate::CONFIG.country_code_operating_class != 0 {
+            cntry_code[2] = crate::CONFIG.country_code_operating_class;
+        }
+
         let country = wifi_country_t {
             cc: core::mem::transmute(cntry_code),
             schan: 1,


### PR DESCRIPTION
This adds an option to configure
- Country Code
- MTU
- HEAP-SIZE
- internal scheduler's tick rate

Probably seems odd we keep the `big-heap` feature for now. It is to not immediately and unnecessarily break `esp-mbedtls` and depending code
