### PR TITLE
Make EspNow methods take immutable borrowed receiver

### DIFF
--- a/examples-esp32/examples/embassy_esp_now.rs
+++ b/examples-esp32/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32/examples/esp_now.rs
+++ b/examples-esp32/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c2/examples/embassy_esp_now.rs
+++ b/examples-esp32c2/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32c2/examples/esp_now.rs
+++ b/examples-esp32c2/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c3/examples/embassy_esp_now.rs
+++ b/examples-esp32c3/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32c3/examples/esp_now.rs
+++ b/examples-esp32c3/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c6/examples/embassy_esp_now.rs
+++ b/examples-esp32c6/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32c6/examples/esp_now.rs
+++ b/examples-esp32c6/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32s2/examples/embassy_esp_now.rs
+++ b/examples-esp32s2/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32s2/examples/esp_now.rs
+++ b/examples-esp32s2/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32s3/examples/embassy_esp_now.rs
+++ b/examples-esp32s3/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(mut esp_now: EspNow<'static>) {
+async fn run(esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {

--- a/examples-esp32s3/examples/esp_now.rs
+++ b/examples-esp32s3/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 


### PR DESCRIPTION
This is what [esp-idf-svc](https://github.com/esp-rs/esp-idf-svc/blob/master/src/espnow.rs) does, and also enables esp now to be used in multiple tasks. Solves #227.