### PR TITLE
Implement duplex ESP-NOW correctly #227

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
         run: cd examples-${{ matrix.chip }} && cargo build --release --example=esp_now --features=esp-now
       - name: check (embassy_esp_now)
         run: cd examples-${{ matrix.chip }} && cargo build --release --example=embassy_esp_now --features=async,esp-now
+      - name: check (esp_now_duplex)
+        run: cd examples-${{ matrix.chip }} && cargo build --release --example=esp_now_duplex --features=async,esp-now
+      - name: check (esp_now_async_duplex)
+        run: cd examples-${{ matrix.chip }} && cargo build --release --example=esp_now_async_duplex --features=async,esp-now
       - name: check (embassy_dhcp)
         run: cd examples-${{ matrix.chip }} && cargo build --release --example=embassy_dhcp --features=async,wifi,embassy-net
       - name: check (embassy_access_point)
@@ -116,6 +120,10 @@ jobs:
         run: cd examples-${{ matrix.chip }} && cargo +nightly-2023-05-16 build --release --example=esp_now --features=esp-now
       - name: check (embassy_esp_now)
         run: cd examples-${{ matrix.chip }} && cargo +nightly-2023-05-16 build --release --example=embassy_esp_now --features=async,esp-now
+      - name: check (esp_now_duplex)
+        run: cd examples-${{ matrix.chip }} && cargo +nightly-2023-05-16 build --release --example=esp_now_duplex --features=async,esp-now
+      - name: check (esp_now_async_duplex)
+        run: cd examples-${{ matrix.chip }} && cargo +nightly-2023-05-16 build --release --example=esp_now_async_duplex --features=async,esp-now
       - name: check (embassy_dhcp)
         run: cd examples-${{ matrix.chip }} && cargo +nightly-2023-05-16 build --release --example=embassy_dhcp --features=async,wifi,embassy-net
       - name: check (embassy_access_point)

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ To build these ensure you are in the `examples-esp32XXX` directory matching your
 
 `cargo run --example embassy_esp_now --release --features "async,esp-now"`        
 
+### esp_now_duplex
+
+- broadcasts, sends and asynchronously receives messages via esp-now in multiple embassy tasks
+
+`cargo run --example esp_now_duplex --release --features "async,esp-now"` 
+
+### esp_now_async_duplex
+
+- asynchronously broadcasts, receives and sends messages via esp-now in multiple embassy tasks
+
+`cargo run --example esp_now_async_duplex --release --features "async,esp-now"` 
+
 ### embassy_dhcp
 
 - Read and Write to sockets over WiFi asyncronously using embassy-executor.

--- a/examples-esp32/Cargo.toml
+++ b/examples-esp32/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32"] }

--- a/examples-esp32/examples/embassy_esp_now.rs
+++ b/examples-esp32/examples/embassy_esp_now.rs
@@ -20,7 +20,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -37,10 +37,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -49,10 +46,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),

--- a/examples-esp32/examples/esp_now.rs
+++ b/examples-esp32/examples/esp_now.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32/examples/esp_now_async_duplex.rs
+++ b/examples-esp32/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32/examples/esp_now_duplex.rs
+++ b/examples-esp32/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c2/Cargo.toml
+++ b/examples-esp32c2/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32c2-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32c2"] }

--- a/examples-esp32c2/examples/embassy_esp_now.rs
+++ b/examples-esp32c2/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -38,10 +38,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -50,10 +47,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),

--- a/examples-esp32c2/examples/esp_now.rs
+++ b/examples-esp32c2/examples/esp_now.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c2/examples/esp_now_async_duplex.rs
+++ b/examples-esp32c2/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c2/examples/esp_now_duplex.rs
+++ b/examples-esp32c2/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c3/Cargo.toml
+++ b/examples-esp32c3/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32c3-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32c3"] }

--- a/examples-esp32c3/examples/embassy_esp_now.rs
+++ b/examples-esp32c3/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -38,10 +38,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -50,10 +47,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status);
             }
             Either::Second(_) => (),

--- a/examples-esp32c3/examples/esp_now.rs
+++ b/examples-esp32c3/examples/esp_now.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c3/examples/esp_now_async_duplex.rs
+++ b/examples-esp32c3/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c3/examples/esp_now_duplex.rs
+++ b/examples-esp32c3/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c6/Cargo.toml
+++ b/examples-esp32c6/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32c6-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32c6"] }

--- a/examples-esp32c6/examples/embassy_esp_now.rs
+++ b/examples-esp32c6/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -38,10 +38,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -50,10 +47,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),

--- a/examples-esp32c6/examples/esp_now.rs
+++ b/examples-esp32c6/examples/esp_now.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32c6/examples/esp_now_async_duplex.rs
+++ b/examples-esp32c6/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32c6/examples/esp_now_duplex.rs
+++ b/examples-esp32c6/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32s2/Cargo.toml
+++ b/examples-esp32s2/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32s2-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32s2"] }

--- a/examples-esp32s2/examples/embassy_esp_now.rs
+++ b/examples-esp32s2/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -38,10 +38,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -50,10 +47,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),

--- a/examples-esp32s2/examples/esp_now.rs
+++ b/examples-esp32s2/examples/esp_now.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32s2/examples/esp_now_async_duplex.rs
+++ b/examples-esp32s2/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32s2/examples/esp_now_duplex.rs
+++ b/examples-esp32s2/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32s3/Cargo.toml
+++ b/examples-esp32s3/Cargo.toml
@@ -17,6 +17,7 @@ smoltcp.workspace = true
 log = { workspace = true, optional = true }
 heapless.workspace = true
 embassy-net = { workspace = true, optional = true }
+embassy-sync.workspace = true
 
 esp32s3-hal.workspace = true
 examples-util = { path = "../examples-util", features = ["esp32s3"] }

--- a/examples-esp32s3/examples/embassy_esp_now.rs
+++ b/examples-esp32s3/examples/embassy_esp_now.rs
@@ -21,7 +21,7 @@ use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc}
 use hal::system::SystemExt;
 
 #[embassy_executor::task]
-async fn run(esp_now: EspNow<'static>) {
+async fn run(mut esp_now: EspNow<'static>) {
     let mut ticker = Ticker::every(Duration::from_secs(5));
     loop {
         let res = select(ticker.next(), async {
@@ -38,10 +38,7 @@ async fn run(esp_now: EspNow<'static>) {
                         })
                         .unwrap();
                 }
-                let status = esp_now
-                    .send_async(&r.info.src_address, b"Hello Peer")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&r.info.src_address, b"Hello Peer").await;
                 println!("Send hello to peer status: {:?}", status);
             }
         })
@@ -50,10 +47,7 @@ async fn run(esp_now: EspNow<'static>) {
         match res {
             Either::First(_) => {
                 println!("Send");
-                let status = esp_now
-                    .send_async(&BROADCAST_ADDRESS, b"0123456789")
-                    .unwrap()
-                    .await;
+                let status = esp_now.send_async(&BROADCAST_ADDRESS, b"0123456789").await;
                 println!("Send broadcast status: {:?}", status)
             }
             Either::Second(_) => (),

--- a/examples-esp32s3/examples/esp_now.rs
+++ b/examples-esp32s3/examples/esp_now.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
     .unwrap();
 
     let wifi = examples_util::get_wifi!(peripherals);
-    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    let mut esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
 
     println!("esp-now version {}", esp_now.get_version().unwrap());
 

--- a/examples-esp32s3/examples/esp_now_async_duplex.rs
+++ b/examples-esp32s3/examples/esp_now_async_duplex.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embassy_sync::mutex::Mutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&BROADCAST_ADDRESS, b"Hello.").await;
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let mut sender = sender.lock().await;
+        let status = sender.send_async(&peer.peer_address, b"Hello Peer.").await;
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<Mutex<NoopRawMutex, EspNowSender<'static>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(Mutex::new(sender));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}

--- a/examples-esp32s3/examples/esp_now_duplex.rs
+++ b/examples-esp32s3/examples/esp_now_duplex.rs
@@ -1,0 +1,138 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::cell::RefCell;
+
+use embassy_executor::_export::StaticCell;
+use embassy_sync::blocking_mutex::NoopMutex;
+use examples_util::hal;
+
+use embassy_executor::Executor;
+use embassy_time::{Duration, Ticker};
+use esp_backtrace as _;
+
+use esp_println::println;
+use esp_wifi::esp_now::{EspNowManager, EspNowReceiver, EspNowSender, PeerInfo, BROADCAST_ADDRESS};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::{ClockControl, CpuClock};
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+
+#[cfg(any(feature = "esp32c3", feature = "esp32c2", feature = "esp32c6"))]
+use hal::system::SystemExt;
+
+#[embassy_executor::task]
+async fn broadcaster(sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>) {
+    let mut ticker = Ticker::every(Duration::from_secs(1));
+    loop {
+        ticker.next().await;
+
+        println!("Send Broadcast...");
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&BROADCAST_ADDRESS, b"Hello.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send broadcast status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn sayhello(
+    manager: &'static EspNowManager<'static>,
+    sender: &'static NoopMutex<RefCell<EspNowSender<'static>>>,
+) {
+    let mut ticker = Ticker::every(Duration::from_millis(500));
+    loop {
+        ticker.next().await;
+        let peer = match manager.fetch_peer(false) {
+            Ok(peer) => peer,
+            Err(_) => {
+                if let Ok(peer) = manager.fetch_peer(true) {
+                    peer
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        println!("Send hello to peer {:?}", peer.peer_address);
+        let status = sender.lock(|sender| {
+            sender
+                .borrow_mut()
+                .send(&peer.peer_address, b"Hello Peer.")
+                .unwrap()
+                .wait()
+        });
+        println!("Send hello status: {:?}", status);
+    }
+}
+
+#[embassy_executor::task]
+async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+    loop {
+        let r = receiver.receive_async().await;
+        println!("Received {:?}", r.get_data());
+        if r.info.dst_address == BROADCAST_ADDRESS {
+            if !manager.peer_exists(&r.info.src_address) {
+                manager
+                    .add_peer(PeerInfo {
+                        peer_address: r.info.src_address,
+                        lmk: None,
+                        channel: None,
+                        encrypt: false,
+                    })
+                    .unwrap();
+                println!("Added peer {:?}", r.info.src_address);
+            }
+        }
+    }
+}
+
+static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+static ESP_NOW_MANAGER: StaticCell<EspNowManager<'static>> = StaticCell::new();
+static ESP_NOW_SENDER: StaticCell<NoopMutex<RefCell<EspNowSender<'static>>>> = StaticCell::new();
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = examples_util::system!(peripherals);
+    let mut peripheral_clock_control = system.peripheral_clock_control;
+    let clocks = examples_util::clocks!(system);
+    examples_util::rtc!(peripherals);
+
+    let timer = examples_util::timer!(peripherals, clocks, peripheral_clock_control);
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = examples_util::get_wifi!(peripherals);
+    let esp_now = esp_wifi::esp_now::EspNow::new(&init, wifi).unwrap();
+    println!("esp-now version {}", esp_now.get_version().unwrap());
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks, &mut peripheral_clock_control);
+    embassy::init(&clocks, timer_group0.timer0);
+    let executor = EXECUTOR.init(Executor::new());
+
+    let (manager, sender, receiver) = esp_now.split();
+    let manager = ESP_NOW_MANAGER.init(manager);
+    let sender: &'static _ = ESP_NOW_SENDER.init(NoopMutex::new(RefCell::new(sender)));
+
+    executor.run(|spawner| {
+        spawner.spawn(listener(manager, receiver)).ok();
+        spawner.spawn(broadcaster(sender)).ok();
+        spawner.spawn(sayhello(manager, sender)).ok();
+    })
+}


### PR DESCRIPTION
This is another try on implementing duplex ESP-NOW #227. This is currently a draft because I think more work should be done to make sure it really works.

I made these changes:

1. I kept the original `EspNow` struct and added `EspNowManager`, `EspNowSender` and `EspNowReceiver`, user can split a `EspNow` to get the later ones.
2. `send` and `send_async` methods now mutably borrow the receiver, thus user will need a mutex when using them concurrently. Also, to make the process `send -> wait for callback` atomic, both `SendWaiter` and `SendFuture` borrow `EspNowSender` to prevent the lock being released before they are dropped or consumed. To prevent user from dropping `SendWaiter` without waiting. There is a `Drop` trait implemented on `SendWaiter` to enforce the waiting. 
3. I found that `receive_async` method also have a risk of creating 'zombie' futures when being used concurrently, so it also mutably borrows the receiver now. `receive` method is left unchanged.

I have tested this implementation in a simple data sending program with two tasks and it works well. 

- [x] Add an example that actually uses the duplex feature