### PR TITLE
Reduce stack-allocations

### DIFF
--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -277,6 +277,9 @@ pub fn initialize(
         rom_ets_update_cpu_frequency(240); // we know it's 240MHz because of the check above
     }
 
+    #[cfg(feature = "wifi")]
+    crate::wifi::DataFrame::internal_init();
+
     log::info!("esp-wifi configuration {:?}", crate::CONFIG);
 
     crate::common_adapter::chip_specific::enable_wifi_power_domain();

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1,7 +1,7 @@
 #[doc(hidden)]
 pub mod os_adapter;
 
-use core::{cell::RefCell, marker::PhantomData, mem::MaybeUninit};
+use core::{cell::RefCell, mem::MaybeUninit};
 
 use crate::common_adapter::*;
 use crate::EspWifiInitialization;
@@ -31,6 +31,7 @@ use esp_wifi_sys::include::wifi_interface_t_WIFI_IF_AP;
 use esp_wifi_sys::include::wifi_mode_t_WIFI_MODE_AP;
 use esp_wifi_sys::include::wifi_mode_t_WIFI_MODE_APSTA;
 use esp_wifi_sys::include::wifi_mode_t_WIFI_MODE_NULL;
+use heapless::Vec;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
@@ -97,31 +98,72 @@ impl WifiMode {
     }
 }
 
+const DATA_FRAMES_MAX_COUNT: usize = RX_QUEUE_SIZE + RX_QUEUE_SIZE;
+const DATA_FRAME_SIZE: usize = MTU + ETHERNET_FRAME_HEADER_SIZE;
+
+static mut DATA_FRAME_BACKING_MEMORY: MaybeUninit<[u8; DATA_FRAMES_MAX_COUNT * DATA_FRAME_SIZE]> =
+    MaybeUninit::uninit();
+
+static DATA_FRAME_BACKING_MEMORY_FREE_SLOTS: Mutex<RefCell<Vec<usize, DATA_FRAMES_MAX_COUNT>>> =
+    Mutex::new(RefCell::new(Vec::new()));
+
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct DataFrame<'a> {
+pub(crate) struct DataFrame {
     len: usize,
-    data: [u8; MTU + ETHERNET_FRAME_HEADER_SIZE],
-    _phantom: PhantomData<&'a ()>,
+    index: usize,
 }
 
-impl<'a> DataFrame<'a> {
-    pub(crate) fn new() -> DataFrame<'a> {
-        DataFrame {
-            len: 0,
-            data: [0u8; MTU + ETHERNET_FRAME_HEADER_SIZE],
-            _phantom: Default::default(),
+impl DataFrame {
+    pub(crate) fn internal_init() {
+        critical_section::with(|cs| {
+            let mut free_slots = DATA_FRAME_BACKING_MEMORY_FREE_SLOTS.borrow_ref_mut(cs);
+            for i in 0..DATA_FRAMES_MAX_COUNT {
+                free_slots.push(i).unwrap();
+            }
+        });
+    }
+
+    pub(crate) fn new() -> DataFrame {
+        let index = critical_section::with(|cs| {
+            DATA_FRAME_BACKING_MEMORY_FREE_SLOTS
+                .borrow_ref_mut(cs)
+                .pop()
+                .expect("Out of DataFrames")
+        });
+
+        DataFrame { len: 0, index }
+    }
+
+    pub(crate) fn free(self) {
+        critical_section::with(|cs| {
+            let mut free_slots = DATA_FRAME_BACKING_MEMORY_FREE_SLOTS.borrow_ref_mut(cs);
+            free_slots.push(self.index).unwrap();
+        });
+    }
+
+    pub(crate) fn data_mut(&mut self) -> &'static mut [u8] {
+        let data = unsafe { DATA_FRAME_BACKING_MEMORY.assume_init_mut() };
+        unsafe {
+            core::mem::transmute(&mut data[(self.index * DATA_FRAME_SIZE)..][..DATA_FRAME_SIZE])
         }
     }
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> DataFrame {
         let mut data = DataFrame::new();
         data.len = bytes.len();
-        data.data[..bytes.len()].copy_from_slice(bytes);
+        let mem = unsafe { DATA_FRAME_BACKING_MEMORY.assume_init_mut() };
+        let len = usize::min(bytes.len(), DATA_FRAME_SIZE);
+        if len != bytes.len() {
+            log::warn!("Trying to store more data than available into DataFrame. Check MTU");
+        }
+
+        mem[(data.index * DATA_FRAME_SIZE)..][..len].copy_from_slice(bytes);
         data
     }
 
-    pub(crate) fn slice(&'a self) -> &'a [u8] {
-        &self.data[..self.len]
+    pub(crate) fn slice(&self) -> &[u8] {
+        let data = unsafe { DATA_FRAME_BACKING_MEMORY.assume_init_ref() };
+        unsafe { core::mem::transmute(&data[(self.index * DATA_FRAME_SIZE)..][..self.len]) }
     }
 }
 
@@ -621,6 +663,7 @@ unsafe extern "C" fn recv_cb(
 
             0
         } else {
+            packet.free();
             log::error!("RX QUEUE FULL");
             1
         }
@@ -978,9 +1021,11 @@ impl RxToken for WifiRxToken {
             let mut data = queue
                 .dequeue()
                 .expect("unreachable: transmit()/receive() ensures there is a packet to process");
-            let buffer = unsafe { core::slice::from_raw_parts(&data.data as *const u8, data.len) };
+            let buffer = &mut data.data_mut()[..data.len];
             dump_packet_info(&buffer);
-            f(&mut data.data[..])
+            let res = f(buffer);
+            data.free();
+            res
         })
     }
 }
@@ -998,7 +1043,7 @@ impl TxToken for WifiTxToken {
 
             let mut packet = DataFrame::new();
             packet.len = len;
-            let res = f(&mut packet.data[..len]);
+            let res = f(&mut packet.data_mut()[..len]);
             queue
                 .enqueue(packet)
                 .expect("unreachable: transmit()/receive() ensures there is a buffer free");
@@ -1024,7 +1069,7 @@ pub fn send_data_if_needed() {
             wifi_mode_t_WIFI_MODE_AP | wifi_mode_t_WIFI_MODE_APSTA
         );
 
-        while let Some(packet) = queue.dequeue() {
+        while let Some(mut packet) = queue.dequeue() {
             log::trace!("sending... {} bytes", packet.len);
             dump_packet_info(packet.slice());
 
@@ -1037,7 +1082,7 @@ pub fn send_data_if_needed() {
             unsafe {
                 let _res = esp_wifi_internal_tx(
                     interface,
-                    &packet.data as *const _ as *mut crate::binary::c_types::c_void,
+                    packet.data_mut() as *const _ as *mut crate::binary::c_types::c_void,
                     packet.len as u16,
                 );
                 if _res != 0 {
@@ -1047,6 +1092,8 @@ pub fn send_data_if_needed() {
             }
             #[cfg(feature = "embassy-net")]
             embassy::TRANSMIT_WAKER.wake();
+
+            packet.free();
         }
     });
 }
@@ -1287,10 +1334,11 @@ pub(crate) mod embassy {
                 let mut data = queue.dequeue().expect(
                     "unreachable: transmit()/receive() ensures there is a packet to process",
                 );
-                let buffer =
-                    unsafe { core::slice::from_raw_parts(&data.data as *const u8, data.len) };
+                let buffer = &mut data.data_mut()[..data.len];
                 dump_packet_info(&buffer);
-                f(&mut data.data[..])
+                let res = f(buffer);
+                data.free();
+                res
             })
         }
     }
@@ -1305,7 +1353,7 @@ pub(crate) mod embassy {
 
                 let mut packet = DataFrame::new();
                 packet.len = len;
-                let res = f(&mut packet.data[..len]);
+                let res = f(&mut packet.data_mut()[..len]);
                 queue
                     .enqueue(packet)
                     .expect("unreachable: transmit()/receive() ensures there is a buffer free");

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -143,11 +143,9 @@ impl DataFrame {
         });
     }
 
-    pub(crate) fn data_mut(&mut self) -> &'static mut [u8] {
+    pub(crate) fn data_mut(&mut self) -> &mut [u8] {
         let data = unsafe { DATA_FRAME_BACKING_MEMORY.assume_init_mut() };
-        unsafe {
-            core::mem::transmute(&mut data[(self.index * DATA_FRAME_SIZE)..][..DATA_FRAME_SIZE])
-        }
+        &mut data[(self.index * DATA_FRAME_SIZE)..][..DATA_FRAME_SIZE]
     }
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> Option<DataFrame> {
@@ -165,7 +163,7 @@ impl DataFrame {
 
     pub(crate) fn slice(&self) -> &[u8] {
         let data = unsafe { DATA_FRAME_BACKING_MEMORY.assume_init_ref() };
-        unsafe { core::mem::transmute(&data[(self.index * DATA_FRAME_SIZE)..][..self.len]) }
+        &data[(self.index * DATA_FRAME_SIZE)..][..self.len]
     }
 }
 
@@ -1028,7 +1026,8 @@ impl RxToken for WifiRxToken {
             let mut data = queue
                 .dequeue()
                 .expect("unreachable: transmit()/receive() ensures there is a packet to process");
-            let buffer = &mut data.data_mut()[..data.len];
+            let len = data.len;
+            let buffer = &mut data.data_mut()[..len];
             dump_packet_info(&buffer);
             let res = f(buffer);
             data.free();
@@ -1341,7 +1340,8 @@ pub(crate) mod embassy {
                 let mut data = queue.dequeue().expect(
                     "unreachable: transmit()/receive() ensures there is a packet to process",
                 );
-                let buffer = &mut data.data_mut()[..data.len];
+                let len = data.len;
+                let buffer = &mut data.data_mut()[..len];
                 dump_packet_info(&buffer);
                 let res = f(buffer);
                 data.free();


### PR DESCRIPTION
Currently there are a lot of stack allocations especially here:

```
Code  Stack Name
 3980  6992 main
  904  4608 <esp_wifi::wifi::WifiTxToken as smoltcp::phy::TxToken>::consume::h03e28a51459eb5a7
  612  4592 esp_wifi::wifi::recv_cb::h76250891538a1884
  700  4592 <esp_wifi::wifi::WifiTxToken as smoltcp::phy::TxToken>::consume::h07b10c4b31c2e16a
  752  4592 <esp_wifi::wifi::WifiTxToken as smoltcp::phy::TxToken>::consume::h1693af2449f9090a
  368  3232 <esp_wifi::wifi::WifiRxToken as smoltcp::phy::RxToken>::consume::hf90923587131582a
  784  3152 esp_wifi::wifi::send_data_if_needed::h08e5ef596584e917
  196  1552 heapless::spsc::Queue<T,_>::inner_dequeue::h6ca259dae19e1234
  196  1552 heapless::spsc::Queue<T,_>::inner_dequeue::h7ab73b821e96b945
```

I first tried to use `heapless::Pool` - that helped a lot but not as much as I wanted.

This PR now uses statically allocated memory backing the `DataFrame`

With that we get to e.g.
```
  598    64 esp_wifi::wifi::recv_cb::h76250891538a1884
```

Which looks quite okay to me.
