### PR TITLE
Remove embedded-hal dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ lto = "off"
 
 [workspace.dependencies]
 defmt = "=0.3.5"
-embedded-hal = "0.2.3"
 esp-hal-common = { version = "0.11.0" }
 esp32c3-hal = { version = "0.11.0" }
 esp32c2-hal = { version = "0.9.0" }

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 defmt = { workspace = true, optional = true }
-embedded-hal.workspace = true
 esp32c3-hal = { workspace = true, optional = true }
 esp32c2-hal = { workspace = true, optional = true }
 esp32c6-hal = { workspace = true, optional = true }


### PR DESCRIPTION
embedded-hal was only used for its `rng::Read` trait, which is not present in 1.0 RC. While it would be nicer first to provide an impl in esp-hal, I don't think it's a problem to copy in 4 lines of code for this.