### PR TITLE
Remove DataFrame, Leverage the internal WiFi heap

### DIFF
--- a/esp-wifi-sys/src/include/esp32.rs
+++ b/esp-wifi-sys/src/include/esp32.rs
@@ -7446,7 +7446,7 @@ pub struct wpa_crypto_funcs_t {
     pub ccmp_encrypt: esp_ccmp_encrypt_t,
     pub aes_gmac: esp_aes_gmac_t,
     pub sha256_vector: esp_sha256_vector_t,
-    pub crc32: esp_crc32_le_t,    
+    pub crc32: esp_crc32_le_t,
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The"]
 #[doc = "        structure can be set as software crypto or the crypto optimized by device's"]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -285,9 +285,6 @@ pub fn initialize(
         rom_ets_update_cpu_frequency(240); // we know it's 240MHz because of the check above
     }
 
-    #[cfg(feature = "wifi")]
-    crate::wifi::DataFrame::internal_init();
-
     info!("esp-wifi configuration {:?}", crate::CONFIG);
 
     crate::common_adapter::chip_specific::enable_wifi_power_domain();

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -85,9 +85,6 @@ pub extern "C" fn worker_task2() {
             trace!("timer callback called");
         }
 
-        #[cfg(feature = "wifi")]
-        crate::wifi::send_data_if_needed();
-
         yield_task();
     }
 }

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -2078,8 +2078,7 @@ pub unsafe extern "C" fn coex_schm_register_cb_wrapper(
     #[cfg(coex)]
     crate::binary::include::coex_schm_register_callback(
         arg1 as u32,
-        unwrap!(cb) as *const esp_wifi_sys::c_types::c_void
-            as *mut esp_wifi_sys::c_types::c_void,
+        unwrap!(cb) as *const esp_wifi_sys::c_types::c_void as *mut esp_wifi_sys::c_types::c_void,
     )
 }
 

--- a/examples-util/src/lib.rs
+++ b/examples-util/src/lib.rs
@@ -94,7 +94,12 @@ macro_rules! boot_button {
 #[macro_export]
 macro_rules! get_bluetooth {
     ($peripherals: ident) => {{
-        #[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32c2", feature = "esp32c3"))]
+        #[cfg(any(
+            feature = "esp32",
+            feature = "esp32s3",
+            feature = "esp32c2",
+            feature = "esp32c3"
+        ))]
         let (_, bluetooth) = $peripherals.RADIO.split();
         #[cfg(any(feature = "esp32c6"))]
         let (_, bluetooth, _) = $peripherals.RADIO.split();
@@ -107,7 +112,12 @@ macro_rules! get_bluetooth {
 #[macro_export]
 macro_rules! get_wifi {
     ($peripherals: ident) => {{
-        #[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32c2", feature = "esp32c3"))]
+        #[cfg(any(
+            feature = "esp32",
+            feature = "esp32s3",
+            feature = "esp32c2",
+            feature = "esp32c3"
+        ))]
         let (wifi, _) = $peripherals.RADIO.split();
         #[cfg(any(feature = "esp32s2"))]
         let wifi = $peripherals.RADIO.split();
@@ -120,7 +130,12 @@ macro_rules! get_wifi {
 #[macro_export]
 macro_rules! get_wifi_bluetooth {
     ($peripherals: ident) => {{
-        #[cfg(any(feature = "esp32", feature = "esp32s3", feature = "esp32c2", feature = "esp32c3"))]
+        #[cfg(any(
+            feature = "esp32",
+            feature = "esp32s3",
+            feature = "esp32c2",
+            feature = "esp32c3"
+        ))]
         let (wifi, bluetooth) = $peripherals.RADIO.split();
         #[cfg(any(feature = "esp32c6"))]
         let (wifi, bluetooth, _) = $peripherals.RADIO.split();


### PR DESCRIPTION
As we know, the WiFi drivers require a heap. We currently set aside 64K; However, we also create a bunch of queues for packets, both on receive and for transmit. This is a bit of a waste, because although we don't really want the heap, we have to have one, so we may as well use it!

This PR does two things:

* Drops all packet storage for receiving on the Rust side, instead we now use the allocated heap storage until its been processed by smoltcp, once that happens the `Drop` impl frees the buffer for the WiFi driver to reuse.
* Removes all packet storage for transmission, and instead _rate limits_ the number of tx packets by the original TX_QUEUE size config option.

Side note: For TX there was another option, which was to use `esp_wifi_internal_tx_by_ref` and allow the WiFi driver to use Rust memory, but this seemed more complicated than the current solution.

## Benefits of this PR

* We should free up around 50KB of RAM, which particularly for the smaller chips is huge.
* Improve performance, we would previously `memcpy` at a whole bunch of places, which should now be minimized, particularly on receive.