### PR TITLE
Implement floor() using libm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ embassy-sync = { version = "0.2.0" }
 embassy-futures = { version = "0.1.0" }
 embassy-net-driver = { version = "0.1.0" }
 toml-cfg = "0.1.3"
+libm = "0.2.7"
 
 embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "b82f1e7009bef7e32f0918be5b186188aa5e7109", features = ["macros"] }

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -29,6 +29,7 @@ embassy-sync = { workspace = true, optional = true }
 embassy-futures = { workspace = true, optional = true }
 embassy-net-driver = { workspace = true, optional = true }
 toml-cfg.workspace = true
+libm.workspace = true
 
 [features]
 default = [ "utils", "log" ]

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -457,6 +457,6 @@ pub unsafe extern "C" fn strrchr(_s: *const (), _c: u32) -> *const u8 {
 
 #[no_mangle]
 #[linkage = "weak"]
-pub unsafe extern "C" fn floor(_v: f64) -> f64 {
-    todo!("floor")
+pub unsafe extern "C" fn floor(v: f64) -> f64 {
+    libm::floor(v)
 }


### PR DESCRIPTION
I hit this exception when trying to connect to wifi on an esp32-c6. `libm` implements the floor function, so let's add that dependency and use it here.