### PR TITLE
Task/semaphore tweaking

### DIFF
--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -466,7 +466,6 @@ pub fn receive_queued(
     unsafe {
         if queue != &mut REAL_WIFI_QUEUE as *mut _ as *mut crate::binary::c_types::c_void {
             panic!("Unknown queue to handle in queue_recv");
-            return -1;
         }
 
         loop {

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -329,14 +329,13 @@ pub fn thread_sem_get() -> *mut crate::binary::c_types::c_void {
     trace!("wifi_thread_semphr_get");
     critical_section::with(|_| unsafe {
         let tid = current_task();
-        if PER_THREAD_SEM[tid].is_none() {
+        if let Some(sem) = PER_THREAD_SEM[tid] {
+            trace!("wifi_thread_semphr_get - return for {} {:?}", tid, sem);
+            sem
+        } else {
             let sem = sem_create(1, 0);
             trace!("wifi_thread_semphr_get - create for {} {:?}", tid, sem);
             PER_THREAD_SEM[tid] = Some(sem);
-            sem
-        } else {
-            let sem = unwrap!(PER_THREAD_SEM[tid]);
-            trace!("wifi_thread_semphr_get - return for {} {:?}", tid, sem);
             sem
         }
     })

--- a/esp-wifi/src/compat/malloc.rs
+++ b/esp-wifi/src/compat/malloc.rs
@@ -9,8 +9,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *const u8 {
 
     let layout = Layout::from_size_align_unchecked(total_size, 4);
     let ptr = critical_section::with(|cs| {
-        HEAP.borrow(cs)
-            .borrow_mut()
+        HEAP.borrow_ref_mut(cs)
             .allocate_first_fit(layout)
             .ok()
             .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
@@ -21,7 +20,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *const u8 {
         return ptr;
     }
 
-    *(ptr as *mut _ as *mut usize) = total_size;
+    *(ptr as *mut usize) = total_size;
     ptr.offset(4)
 }
 
@@ -37,8 +36,7 @@ pub unsafe extern "C" fn free(ptr: *const u8) {
 
     let layout = Layout::from_size_align_unchecked(total_size, 4);
     critical_section::with(|cs| {
-        HEAP.borrow(cs)
-            .borrow_mut()
+        HEAP.borrow_ref_mut(cs)
             .deallocate(core::ptr::NonNull::new_unchecked(ptr as *mut u8), layout)
     });
 }

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -22,10 +22,9 @@ pub fn compat_timer_arm(ptimer: *mut crate::binary::c_types::c_void, tmout: u32,
 }
 
 pub fn compat_timer_arm_us(ptimer: *mut crate::binary::c_types::c_void, us: u32, repeat: bool) {
-    debug!(
-        "timer_arm_us, current time {}",
-        crate::timer::get_systimer_count()
-    );
+    let systick = crate::timer::get_systimer_count();
+
+    debug!("timer_arm_us, current time {}", systick);
 
     let ticks = us as u64 * (crate::timer::TICKS_PER_SECOND / 1_000_000);
     debug!("timer_arm_us {:?} {} {}", ptimer, ticks, repeat);
@@ -38,13 +37,9 @@ pub fn compat_timer_arm_us(ptimer: *mut crate::binary::c_types::c_void, us: u32,
 
                 if timer.ptimer == ptimer {
                     trace!("found timer ...");
-                    timer.expire = ticks as u64 + crate::timer::get_systimer_count();
+                    timer.expire = ticks + systick;
                     timer.active = true;
-                    if repeat {
-                        timer.period = ticks as u64;
-                    } else {
-                        timer.period = 0;
-                    }
+                    timer.period = if repeat { ticks } else { 0 };
                     TIMERS[i] = Some(timer);
                     break;
                 }

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -153,8 +153,6 @@ pub fn compat_esp_timer_create(
         );
     }
 
-    let args = args as *const esp_timer_create_args_t;
-
     critical_section::with(|_| unsafe {
         let mut timer_found = false;
         memory_fence();

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -94,7 +94,7 @@ pub fn compat_timer_setfn(
     pfunction: *mut crate::binary::c_types::c_void,
     parg: *mut crate::binary::c_types::c_void,
 ) {
-    trace!("timer_setfn {:?} {:?} {:?}", ptimer, pfunction, parg,);
+    trace!("timer_setfn {:?} {:?} {:?}", ptimer, pfunction, parg);
 
     critical_section::with(|_| unsafe {
         memory_fence();
@@ -116,13 +116,12 @@ pub fn compat_timer_setfn(
         (*ets_timer).expire = 0;
 
         if !timer_found {
-            for i in 0..TIMERS.len() {
-                (*ets_timer).next = core::ptr::null_mut();
-                (*ets_timer).expire = 0;
-                (*ets_timer).period = 0;
-                (*ets_timer).func = None;
-                (*ets_timer).priv_ = core::ptr::null_mut();
+            (*ets_timer).next = core::ptr::null_mut();
+            (*ets_timer).period = 0;
+            (*ets_timer).func = None;
+            (*ets_timer).priv_ = core::ptr::null_mut();
 
+            for i in 0..TIMERS.len() {
                 if TIMERS[i].is_none() {
                     TIMERS[i] = Some(Timer {
                         ptimer,

--- a/esp-wifi/src/compat/work_queue.rs
+++ b/esp-wifi/src/compat/work_queue.rs
@@ -43,32 +43,22 @@ pub fn do_work() {
         )>; 10] = [None; 10];
 
         critical_section::with(|_| {
-            if WORKER_HIGH.is_none() {
-                return;
-            }
-
-            todo.iter_mut().for_each(|e| {
-                let work = &unwrap!(WORKER_HIGH.as_mut()).dequeue();
-
-                match work {
-                    Some(worker) => {
-                        e.replace(*worker);
+            if let Some(queue) = WORKER_HIGH.as_mut() {
+                todo.iter_mut().for_each(|e| {
+                    if let Some(worker) = queue.dequeue() {
+                        e.replace(worker);
                     }
-                    None => {}
-                }
-            });
+                });
+            }
         });
 
         for worker in todo.iter() {
-            match worker {
-                core::option::Option::Some((f, p)) => {
-                    trace!("before worker {:?} {:?}", f, *p);
+            if let Some((f, p)) = worker {
+                trace!("before worker {:?} {:?}", f, *p);
 
-                    f(*p);
+                f(*p);
 
-                    trace!("after worker");
-                }
-                core::option::Option::None => {}
+                trace!("after worker");
             }
         }
     }

--- a/esp-wifi/src/compat/work_queue.rs
+++ b/esp-wifi/src/compat/work_queue.rs
@@ -25,7 +25,12 @@ pub fn queue_work(
     );
 
     critical_section::with(|_| unsafe {
-        let _ = WORKER_HIGH.enqueue((core::mem::transmute(task_func), param));
+        if WORKER_HIGH
+            .enqueue((core::mem::transmute(task_func), param))
+            .is_err()
+        {
+            warn!("work queue full");
+        }
     });
 }
 

--- a/esp-wifi/src/compat/work_queue.rs
+++ b/esp-wifi/src/compat/work_queue.rs
@@ -31,10 +31,7 @@ pub fn queue_work(
 
 pub fn do_work() {
     unsafe {
-        let mut todo: [Option<(
-            extern "C" fn(*mut crate::binary::c_types::c_void),
-            *mut crate::binary::c_types::c_void,
-        )>; 10] = [None; 10];
+        let mut todo = [None; 10];
 
         critical_section::with(|_| {
             todo.iter_mut().for_each(|e| {

--- a/esp-wifi/src/compat/work_queue.rs
+++ b/esp-wifi/src/compat/work_queue.rs
@@ -1,20 +1,19 @@
+use crate::binary::c_types;
+
 use super::queue::SimpleQueue;
 
 static mut WORKER_HIGH: SimpleQueue<
-    (
-        extern "C" fn(*mut crate::binary::c_types::c_void),
-        *mut crate::binary::c_types::c_void,
-    ),
+    (extern "C" fn(*mut c_types::c_void), *mut c_types::c_void),
     10,
 > = SimpleQueue::new();
 
 pub fn queue_work(
-    task_func: *mut crate::binary::c_types::c_void,
-    _name: *const crate::binary::c_types::c_char,
+    task_func: *mut c_types::c_void,
+    _name: *const c_types::c_char,
     _stack_depth: u32,
-    param: *mut crate::binary::c_types::c_void,
+    param: *mut c_types::c_void,
     prio: u32,
-    _task_handle: *mut crate::binary::c_types::c_void,
+    _task_handle: *mut c_types::c_void,
     _core_id: u32,
 ) {
     trace!(

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -162,8 +162,7 @@ pub(crate) static HEAP: Mutex<RefCell<Heap>> = Mutex::new(RefCell::new(Heap::emp
 
 fn init_heap() {
     critical_section::with(|cs| {
-        HEAP.borrow(cs)
-            .borrow_mut()
+        HEAP.borrow_ref_mut(cs)
             .init_from_slice(unsafe { &mut HEAP_DATA })
     });
 }

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -1,4 +1,7 @@
+use core::mem;
+
 use crate::{
+    binary::c_types,
     compat::{
         self,
         queue::SimpleQueue,
@@ -43,8 +46,7 @@ pub extern "C" fn worker_task2() {
                 if let Some(ref mut timer) = TIMERS[i] {
                     if timer.active && current_timestamp >= timer.expire {
                         debug!("timer is due.... {:?}", timer.ptimer);
-                        let fnctn: fn(*mut crate::binary::c_types::c_void) =
-                            core::mem::transmute(timer.timer_ptr);
+                        let fnctn: fn(*mut c_types::c_void) = mem::transmute(timer.timer_ptr);
 
                         _ = to_run.enqueue((fnctn, timer.arg_ptr));
 

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -2,11 +2,7 @@ use core::mem;
 
 use crate::{
     binary::c_types,
-    compat::{
-        self,
-        queue::SimpleQueue,
-        timer_compat::{Timer, TIMERS},
-    },
+    compat::{self, queue::SimpleQueue, timer_compat::TIMERS},
     memory_fence::memory_fence,
     preempt::preempt::task_create,
     timer::{get_systimer_count, yield_task},

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -34,13 +34,7 @@ pub extern "C" fn worker_task3() {
 
 pub extern "C" fn worker_task2() {
     loop {
-        let mut to_run: SimpleQueue<
-            (
-                fn(*mut crate::binary::c_types::c_void),
-                *mut crate::binary::c_types::c_void,
-            ),
-            10,
-        > = SimpleQueue::new();
+        let mut to_run = SimpleQueue::<_, 20>::new();
 
         critical_section::with(|_| unsafe {
             let current_timestamp = get_systimer_count();
@@ -52,7 +46,8 @@ pub extern "C" fn worker_task2() {
                         debug!("timer is due.... {:?}", timer.ptimer);
                         let fnctn: fn(*mut crate::binary::c_types::c_void) =
                             core::mem::transmute(timer.timer_ptr);
-                        unwrap!(to_run.enqueue((fnctn, timer.arg_ptr)));
+
+                        _ = to_run.enqueue((fnctn, timer.arg_ptr));
 
                         if timer.period != 0 {
                             timer.expire = current_timestamp + timer.period;

--- a/esp-wifi/src/tasks.rs
+++ b/esp-wifi/src/tasks.rs
@@ -41,7 +41,6 @@ pub extern "C" fn worker_task2() {
             memory_fence();
             for i in 0..TIMERS.len() {
                 if let Some(ref mut timer) = TIMERS[i] {
-                    memory_fence();
                     if timer.active && current_timestamp >= timer.expire {
                         debug!("timer is due.... {:?}", timer.ptimer);
                         let fnctn: fn(*mut crate::binary::c_types::c_void) =
@@ -59,6 +58,7 @@ pub extern "C" fn worker_task2() {
                     }
                 };
             }
+            memory_fence();
         });
 
         // run the due timer callbacks NOT in an interrupt free context


### PR DESCRIPTION
`get_systimer_count()` is an `AtomicU64` which is implemented using a critical section. The compiler is not smart enough to remove nested critical sections, so they mostly just waste time. If the slightly closer deadlines (caused by hoisting the timestamp reading out of the loop) can be tolerated, this PR should reduce instruction counts slightly in every loop iteration.

`WORKER_HIGH` doesn't need to be in an `Option`. It can be static-initialized instead.

`TIMERS` are only accessed in critical sections. I don't believe memory fencing is necessary between accessing individual array elements, though I admit I'm not quite sure what a fence achieves at all here.

All in all, this PR results in about 1kB reduction in firmware size for me.