### PR TITLE
Remove StrBuf

### DIFF
--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -7,7 +7,7 @@ use crate::ble::HciOutCollector;
 use crate::ble::HCI_OUT_COLLECTOR;
 use crate::{
     binary::include::*,
-    compat::{common::StrBuf, queue::SimpleQueue, work_queue::queue_work},
+    compat::{common::str_from_c, queue::SimpleQueue, work_queue::queue_work},
     memory_fence::memory_fence,
     timer::yield_task,
 };
@@ -288,12 +288,12 @@ unsafe extern "C" fn task_create(
     handle: *mut crate::binary::c_types::c_void,
     core_id: u32,
 ) -> i32 {
-    let n = StrBuf::from(name);
+    let n = str_from_c(name);
     trace!(
         "task_create {:?} {:?} {} {} {:?} {} {:?} {}",
         func,
         name,
-        n.as_str_ref(),
+        n,
         stack_depth,
         param,
         prio,
@@ -479,8 +479,8 @@ pub(crate) fn ble_init() {
         }
 
         let version = btdm_controller_get_compile_version();
-        let version_str = StrBuf::from(version);
-        debug!("BT controller compile version {}", version_str.as_str_ref());
+        let version_str = str_from_c(version);
+        debug!("BT controller compile version {}", version_str);
 
         ble_os_adapter_chip_specific::bt_periph_module_enable();
 

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::binary::c_types::c_void;
 use crate::binary::include::*;
 use crate::compat;
-use crate::compat::common::StrBuf;
+use crate::compat::common::str_from_c;
 use crate::compat::queue::SimpleQueue;
 use crate::timer::yield_task;
 
@@ -372,11 +372,11 @@ unsafe extern "C" fn task_create(
     task_handle: *const crate::binary::c_types::c_void,
     core_id: u32,
 ) -> i32 {
-    let name_str = StrBuf::from(name as *const u8);
+    let name_str = str_from_c(name as *const u8);
     trace!(
         "task_create {:?} {} {} {:?} {} {:?} {}",
         task_func,
-        name_str.as_str_ref(),
+        name_str,
         stack_depth,
         param,
         prio,
@@ -409,14 +409,8 @@ unsafe extern "C" fn osi_assert(
     param1: u32,
     param2: u32,
 ) {
-    let name_str = StrBuf::from(fn_name as *const u8);
-    panic!(
-        "ASSERT {}:{} {} {}",
-        name_str.as_str_ref(),
-        ln,
-        param1,
-        param2
-    );
+    let name_str = str_from_c(fn_name as *const u8);
+    panic!("ASSERT {}:{} {} {}", name_str, ln, param1, param2);
 }
 
 unsafe extern "C" fn esp_intr_free(_ret_handle: *mut *mut crate::binary::c_types::c_void) -> i32 {

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -1,7 +1,7 @@
 use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
 use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
-use crate::compat::common::StrBuf;
+use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 use atomic_polyfill::AtomicU32;
@@ -36,10 +36,7 @@ pub(crate) unsafe fn phy_enable() {
                     [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
 
                 let phy_version = get_phy_version_str();
-                trace!(
-                    "phy_version {}",
-                    StrBuf::from(phy_version as *const u8).as_str_ref()
-                );
+                trace!("phy_version {}", str_from_c(phy_version as *const u8));
 
                 let init_data = &PHY_INIT_DATA_DEFAULT;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -1,7 +1,7 @@
 use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
 use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
-use crate::compat::common::StrBuf;
+use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 use atomic_polyfill::AtomicU32;
@@ -71,10 +71,7 @@ pub(crate) unsafe fn phy_enable() {
                     [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
 
                 let phy_version = get_phy_version_str();
-                trace!(
-                    "phy_version {}",
-                    StrBuf::from(phy_version as *const u8).as_str_ref()
-                );
+                trace!("phy_version {}", str_from_c(phy_version as *const u8));
 
                 let init_data = &PHY_INIT_DATA_DEFAULT;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -1,7 +1,7 @@
 use super::phy_init_data::PHY_INIT_DATA_DEFAULT;
 use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
-use crate::compat::common::StrBuf;
+use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 use atomic_polyfill::AtomicU32;
@@ -36,10 +36,7 @@ pub(crate) unsafe fn phy_enable() {
                     [0u8; core::mem::size_of::<esp_phy_calibration_data_t>()];
 
                 let phy_version = get_phy_version_str();
-                trace!(
-                    "phy_version {}",
-                    StrBuf::from(phy_version as *const u8).as_str_ref()
-                );
+                trace!("phy_version {}", str_from_c(phy_version as *const u8));
 
                 let init_data = &PHY_INIT_DATA_DEFAULT;
 

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -318,19 +318,19 @@ pub(crate) unsafe extern "C" fn semphr_give_from_isr(sem: *const (), hptw: *cons
 // other functions
 #[no_mangle]
 pub unsafe extern "C" fn puts(s: *const u8) {
-    let cstr = StrBuf::from(s);
-    trace!("{}", cstr.as_str_ref());
+    let cstr = str_from_c(s);
+    trace!("{}", cstr);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sprintf(dst: *mut u8, format: *const u8, args: ...) -> i32 {
-    let str = StrBuf::from(format);
-    trace!("sprintf {}", str.as_str_ref());
+    let str = str_from_c(format);
+    trace!("sprintf format: {}", str);
 
-    let len = crate::compat::common::vsnprintf(dst, 511, format, args);
+    let len = crate::compat::common::vsnprintf(dst, 512, format, args);
 
-    let s = StrBuf::from(dst);
-    trace!("sprintf {}", s.as_str_ref());
+    let s = str_from_c(dst);
+    trace!("sprintf result: {}", s);
 
     len
 }


### PR DESCRIPTION
StrBuf has two responsibilities:

 - StrBuf is mostly used to turn a `*const u8` into a `&str`. While this is completely unsafe to do, using the same assumptions it's much more efficient to turn the pointer into a slice instead of copying the string.
 - StrBuf is used as a string builder. The string is assembled in a local buffer, then copied to the destination pointer unconditionally. I've replaced this with direct writing into the destination pointer.