### PR TITLE
Set inactive time only for ps-max-modem

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG since it might re
 | big-heap       | Reserve more heap memory for the drivers                                                            |
 | ipv6           | IPv6 support                                                                                        |
 | phy-enable-usb | See _USB-SERIAL-JTAG_ below                                                                         |
-| ps-min-modem   | Enable minimum modem sleep                                                                          |
-| ps-max-modem   | Enable maximum modem sleep                                                                          |
+| ps-min-modem   | Enable minimum modem sleep. Only for STA mode                                                       |
+| ps-max-modem   | Enable maximum modem sleep. Only for STA mode                                                       |
 | log            | Route log output to the `log` crate                                                                 |
 | defmt          | Add `defmt::Format` implementation                                                                  |
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -17,7 +17,6 @@ use enumset::EnumSetType;
 use esp_wifi_sys::include::esp_interface_t_ESP_IF_WIFI_AP;
 use esp_wifi_sys::include::esp_wifi_disconnect;
 use esp_wifi_sys::include::esp_wifi_get_mode;
-use esp_wifi_sys::include::esp_wifi_set_inactive_time;
 use esp_wifi_sys::include::esp_wifi_set_protocol;
 use esp_wifi_sys::include::wifi_ap_config_t;
 use esp_wifi_sys::include::wifi_auth_mode_t_WIFI_AUTH_WAPI_PSK;
@@ -641,7 +640,9 @@ unsafe extern "C" fn esp_wifi_tx_done_cb(
 pub fn wifi_start() -> Result<(), WifiError> {
     unsafe {
         esp_wifi_result!(esp_wifi_start())?;
-        esp_wifi_result!(esp_wifi_set_inactive_time(
+
+        #[cfg(feature = "ps-max-modem")]
+        esp_wifi_result!(esp_wifi_sys::include::esp_wifi_set_inactive_time(
             wifi_interface_t_WIFI_IF_STA,
             crate::CONFIG.beacon_timeout
         ))?;


### PR DESCRIPTION
In #273 I added unconditionally setting the inactive time. But setting the inactive time and using AP mode doesn't work.

Now `esp_wifi_set_inactive_time` is only done for `ps-max-modem` - it doesn't have any effect otherwise anyways (besides making AP not work anymore)
