### PR TITLE
Split wifi state for AP and STA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ esp32s2-hal = { version = "0.12.0" }
 smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "proto-dns", "socket-tcp", "socket-icmp", "socket-udp", "socket-dns", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 critical-section = "1.1.1"
 atomic-polyfill = "1.0.2"
+atomic_enum = "0.2.0" # uses core atomic types which should be fine as long as only load and store is used on them
 log = "0.4.18"
 embedded-svc = { version = "0.25.1", default-features = false, features = [] }
 enumset = { version = "1", default-features = false }

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -14,7 +14,6 @@ esp32s3-hal = { workspace = true, optional = true }
 esp32s2-hal = { workspace = true, optional = true }
 smoltcp = { workspace = true, optional = true }
 critical-section.workspace = true
-atomic-polyfill.workspace = true
 log = { workspace = true, optional = true }
 embedded-svc = { workspace = true, optional = true }
 enumset = { workspace = true, optional = true }
@@ -31,6 +30,8 @@ embassy-net-driver = { workspace = true, optional = true }
 toml-cfg.workspace = true
 libm.workspace = true
 cfg-if.workspace = true
+atomic-polyfill = { workspace = true }
+atomic_enum = { workspace = true }
 
 [features]
 default = [ "utils", "log" ]

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -3,8 +3,10 @@ use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
-use atomic_polyfill::AtomicU32;
 use esp32_hal::prelude::ram;
+
+use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -36,7 +38,7 @@ pub(crate) fn phy_mem_init() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             // #if CONFIG_IDF_TARGET_ESP32
@@ -77,7 +79,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();
@@ -116,7 +118,7 @@ fn phy_digital_regs_store() {
 pub(crate) unsafe fn phy_enable_clock() {
     trace!("phy_enable_clock");
 
-    let count = PHY_CLOCK_ENABLE_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_CLOCK_ENABLE_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             unwrap!(RADIO_CLOCKS.as_mut()).enable(RadioPeripherals::Phy);
@@ -128,7 +130,7 @@ pub(crate) unsafe fn phy_enable_clock() {
 pub(crate) unsafe fn phy_disable_clock() {
     trace!("phy_disable_clock");
 
-    let count = PHY_CLOCK_ENABLE_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_CLOCK_ENABLE_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             unwrap!(RADIO_CLOCKS.as_mut()).disable(RadioPeripherals::Phy);

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -4,7 +4,9 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
+
 use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -26,7 +28,7 @@ pub(crate) fn phy_mem_init() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             phy_enable_clock();
@@ -77,7 +79,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -4,7 +4,9 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
+
 use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -61,7 +63,7 @@ pub(crate) fn phy_mem_init() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             phy_enable_clock();
@@ -112,7 +114,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -4,7 +4,9 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
+
 use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -26,7 +28,7 @@ pub(crate) fn phy_mem_init() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             phy_enable_clock();
@@ -76,7 +78,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -3,8 +3,10 @@ use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
-use atomic_polyfill::AtomicU32;
 use esp32s2_hal::prelude::ram;
+
+use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -59,7 +61,7 @@ pub(crate) fn phy_mem_init() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             phy_enable_clock();
@@ -96,7 +98,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();
@@ -130,7 +132,7 @@ fn phy_digital_regs_store() {
 }
 
 pub(crate) unsafe fn phy_enable_clock() {
-    let count = PHY_CLOCK_ENABLE_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_CLOCK_ENABLE_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             unwrap!(RADIO_CLOCKS.as_mut()).enable(RadioPeripherals::Phy);
@@ -142,7 +144,7 @@ pub(crate) unsafe fn phy_enable_clock() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable_clock() {
-    let count = PHY_CLOCK_ENABLE_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_CLOCK_ENABLE_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             unwrap!(RADIO_CLOCKS.as_mut()).disable(RadioPeripherals::Phy);

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -3,7 +3,9 @@ use crate::binary::include::*;
 use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
+
 use atomic_polyfill::AtomicU32;
+use core::sync::atomic::Ordering;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -60,7 +62,7 @@ pub(crate) fn enable_wifi_power_domain() {
 }
 
 pub(crate) unsafe fn phy_enable() {
-    let count = PHY_ACCESS_REF.fetch_add(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_add(1, Ordering::SeqCst);
     if count == 0 {
         critical_section::with(|_| {
             phy_enable_clock();
@@ -108,7 +110,7 @@ pub(crate) unsafe fn phy_enable() {
 
 #[allow(unused)]
 pub(crate) unsafe fn phy_disable() {
-    let count = PHY_ACCESS_REF.fetch_sub(1, atomic_polyfill::Ordering::SeqCst);
+    let count = PHY_ACCESS_REF.fetch_sub(1, Ordering::SeqCst);
     if count == 1 {
         critical_section::with(|_| {
             phy_digital_regs_store();

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -7,9 +7,11 @@
 //! For more information see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_now.html
 
 use core::marker::PhantomData;
+use core::sync::atomic::Ordering;
 use core::{cell::RefCell, fmt::Debug};
 
-use atomic_polyfill::{AtomicBool, AtomicU8, Ordering};
+use atomic_polyfill::{AtomicBool, AtomicU8};
+
 use critical_section::Mutex;
 
 use crate::compat::queue::SimpleQueue;

--- a/esp-wifi/src/preempt/mod.rs
+++ b/esp-wifi/src/preempt/mod.rs
@@ -1,4 +1,5 @@
-use atomic_polyfill::*;
+use atomic_polyfill::AtomicBool;
+use core::sync::atomic::Ordering;
 
 pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
 

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -1,4 +1,5 @@
 use core::cell::RefCell;
+use core::sync::atomic::Ordering;
 
 use critical_section::Mutex;
 
@@ -50,7 +51,7 @@ pub fn setup_multitasking() {
         riscv::interrupt::enable();
     }
 
-    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(Ordering::Relaxed) } {}
 }
 
 #[interrupt]

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -1,4 +1,6 @@
+use atomic_polyfill::AtomicU32;
 use core::cell::RefCell;
+use core::sync::atomic::Ordering;
 
 use critical_section::Mutex;
 
@@ -14,7 +16,6 @@ use crate::{
     },
     preempt::preempt::task_switch,
 };
-use atomic_polyfill::{AtomicU32, Ordering};
 
 pub type TimeBase = Timer<Timer0<TIMG1>>;
 
@@ -72,7 +73,7 @@ pub fn setup_multitasking() {
         );
     }
 
-    while unsafe { crate::preempt::FIRST_SWITCH.load(core::sync::atomic::Ordering::Relaxed) } {}
+    while unsafe { crate::preempt::FIRST_SWITCH.load(Ordering::Relaxed) } {}
 }
 
 #[allow(non_snake_case)]

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1238,10 +1238,7 @@ impl Wifi for WifiController<'_> {
     }
 
     fn connect(&mut self) -> Result<(), Self::Error> {
-        esp_wifi_result!(unsafe {
-            WIFI_STATE = -1;
-            esp_wifi_connect()
-        })
+        esp_wifi_result!(unsafe { esp_wifi_connect() })
     }
 
     fn disconnect(&mut self) -> Result<(), Self::Error> {
@@ -1249,15 +1246,20 @@ impl Wifi for WifiController<'_> {
     }
 
     fn is_started(&self) -> Result<bool, Self::Error> {
-        match crate::wifi::get_wifi_state() {
-            crate::wifi::WifiState::Invalid => Ok(false),
-            // We assume that wifi has been started in every other states
-            _ => Ok(true),
+        if matches!(
+            crate::wifi::get_sta_state(),
+            WifiState::StaStarted | WifiState::StaConnected | WifiState::StaDisconnected
+        ) {
+            return Ok(true);
         }
+        if matches!(crate::wifi::get_ap_state(), WifiState::ApStarted) {
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     fn is_connected(&self) -> Result<bool, Self::Error> {
-        match crate::wifi::get_wifi_state() {
+        match crate::wifi::get_sta_state() {
             crate::wifi::WifiState::StaConnected => Ok(true),
             crate::wifi::WifiState::StaDisconnected => Err(WifiError::Disconnected),
             //FIXME: Should any other enum value trigger an error instead of returning false?
@@ -1355,19 +1357,14 @@ pub(crate) mod embassy {
 
             match self.get_wifi_mode() {
                 Ok(WifiMode::Sta) => {
-                    if matches!(get_wifi_state(), WifiState::StaConnected) {
+                    if matches!(get_sta_state(), WifiState::StaConnected) {
                         embassy_net_driver::LinkState::Up
                     } else {
                         embassy_net_driver::LinkState::Down
                     }
                 }
                 Ok(WifiMode::Ap) => {
-                    if matches!(
-                        get_wifi_state(),
-                        WifiState::ApStart
-                            | WifiState::ApStaConnected
-                            | WifiState::ApStaDisconnected
-                    ) {
+                    if matches!(get_ap_state(), WifiState::ApStarted) {
                         embassy_net_driver::LinkState::Up
                     } else {
                         embassy_net_driver::LinkState::Down
@@ -1463,7 +1460,10 @@ mod asynch {
             embedded_svc::wifi::Wifi::stop(self)?;
             WifiEventFuture::new(event).await;
 
-            unsafe { WIFI_STATE = -1 };
+            unsafe {
+                AP_STATE = WifiState::Invalid;
+                STA_STATE = WifiState::Invalid;
+            }
 
             Ok(())
         }

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1,6 +1,8 @@
 #[doc(hidden)]
 pub mod os_adapter;
 
+use atomic_polyfill::AtomicUsize;
+use core::sync::atomic::Ordering;
 use core::{cell::RefCell, mem::MaybeUninit};
 
 use crate::common_adapter::*;
@@ -34,9 +36,6 @@ use esp_wifi_sys::include::wifi_mode_t_WIFI_MODE_APSTA;
 use esp_wifi_sys::include::wifi_mode_t_WIFI_MODE_NULL;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-
-use atomic_polyfill::AtomicUsize;
-use core::sync::atomic::Ordering;
 
 #[doc(hidden)]
 pub use os_adapter::*;
@@ -1461,8 +1460,8 @@ mod asynch {
             WifiEventFuture::new(event).await;
 
             unsafe {
-                AP_STATE = WifiState::Invalid;
-                STA_STATE = WifiState::Invalid;
+                AP_STATE.store(WifiState::Invalid, Ordering::Relaxed);
+                STA_STATE.store(WifiState::Invalid, Ordering::Relaxed);
             }
 
             Ok(())

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1459,10 +1459,8 @@ mod asynch {
             embedded_svc::wifi::Wifi::stop(self)?;
             WifiEventFuture::new(event).await;
 
-            unsafe {
-                AP_STATE.store(WifiState::Invalid, Ordering::Relaxed);
-                STA_STATE.store(WifiState::Invalid, Ordering::Relaxed);
-            }
+            AP_STATE.store(WifiState::Invalid, Ordering::Relaxed);
+            STA_STATE.store(WifiState::Invalid, Ordering::Relaxed);
 
             Ok(())
         }

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -42,7 +42,7 @@ pub(crate) static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
     Mutex::new(RefCell::new(enumset::enum_set!()));
 
 pub fn is_connected() -> bool {
-    unsafe { get_sta_state() == WifiState::StaConnected }
+    get_sta_state() == WifiState::StaConnected
 }
 
 #[atomic_enum]

--- a/examples-esp32/examples/embassy_access_point.rs
+++ b/examples-esp32/examples/embassy_access_point.rs
@@ -104,7 +104,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await

--- a/examples-esp32c2/examples/embassy_access_point.rs
+++ b/examples-esp32c2/examples/embassy_access_point.rs
@@ -100,7 +100,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await

--- a/examples-esp32c3/examples/embassy_access_point.rs
+++ b/examples-esp32c3/examples/embassy_access_point.rs
@@ -100,7 +100,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await

--- a/examples-esp32c6/examples/embassy_access_point.rs
+++ b/examples-esp32c6/examples/embassy_access_point.rs
@@ -100,7 +100,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await

--- a/examples-esp32s2/examples/embassy_access_point.rs
+++ b/examples-esp32s2/examples/embassy_access_point.rs
@@ -105,7 +105,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await

--- a/examples-esp32s3/examples/embassy_access_point.rs
+++ b/examples-esp32s3/examples/embassy_access_point.rs
@@ -105,7 +105,7 @@ async fn connection(mut controller: WifiController<'static>) {
     println!("Device capabilities: {:?}", controller.get_capabilities());
     loop {
         match esp_wifi::wifi::get_wifi_state() {
-            WifiState::ApStart => {
+            WifiState::ApStarted => {
                 // wait until we're no longer connected
                 controller.wait_for_event(WifiEvent::ApStop).await;
                 Timer::after(Duration::from_millis(5000)).await


### PR DESCRIPTION
Closes #210

I wonder what to do with the combined `get_wifi_state()` function in the long run. If esp-wifi ever gets AP-STA support, picking one state will be difficult. Maybe the current "none of these modes? then invalid" logic will be good enough, or maybe that function can be removed altogether. I'm not sure.

I've removed a bunch of possibilities from the set of states, based on what I found [here](https://github.com/esp-rs/esp-idf-svc/blob/1e0edec70e7fa939e3594aef73a4ebe0f7646444/src/wifi.rs#L460). If it weren't a breaking change, I have also renamed the event-like `ApStop`, etc. enum variants to a more grammatically proper form (e.g. `ApStopped`).