### PR TITLE
Enable `vsnprintf` on compilers newer than `1.73.0.1`

### DIFF
--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -319,7 +319,7 @@ pub(crate) unsafe extern "C" fn semphr_give_from_isr(sem: *const (), hptw: *cons
 #[no_mangle]
 pub unsafe extern "C" fn puts(s: *const u8) {
     let cstr = str_from_c(s);
-    trace!("{}", cstr);
+    info!("{}", cstr);
 }
 
 #[no_mangle]

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -106,15 +106,15 @@ pub unsafe fn str_from_c<'a>(s: *const u8) -> &'a str {
 
 pub unsafe extern "C" fn syslog(_priority: u32, format: *const u8, mut args: VaListImpl) {
     #[cfg(feature = "wifi-logs")]
-    {
-        #[cfg(target_arch = "riscv32")]
+    cfg_if::cfg_if! {
+        if #[cfg(any(target_arch = "riscv32", all(target_arch = "xtensa", xtensa_has_vaarg)))]
         {
             let mut buf = [0u8; 512];
             vsnprintf(&mut buf as *mut u8, 512, format, args);
             let res_str = str_from_c(&buf as *const u8);
             info!("{}", res_str);
         }
-        #[cfg(not(target_arch = "riscv32"))]
+        else
         {
             let res_str = str_from_c(format);
             info!("{}", res_str);

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -28,7 +28,6 @@ use crate::{
     timer::yield_task,
 };
 
-#[cfg(target_arch = "riscv32")]
 use crate::compat::common::syslog;
 
 use super::WifiEvent;
@@ -1508,10 +1507,7 @@ pub unsafe extern "C" fn log_write(
     _format: *const crate::binary::c_types::c_char,
     _args: ...
 ) {
-    #[cfg(not(feature = "wifi-logs"))]
-    return;
-
-    #[cfg(target_arch = "riscv32")]
+    let _args = core::mem::transmute(_args);
     syslog(_level, _format as *const u8, _args);
 }
 
@@ -1538,20 +1534,8 @@ pub unsafe extern "C" fn log_writev(
     _format: *const crate::binary::c_types::c_char,
     _args: va_list,
 ) {
-    #[cfg(feature = "wifi-logs")]
-    {
-        #[cfg(target_arch = "xtensa")]
-        {
-            let s = str_from_c(_format as *const u8);
-            info!("{}", s);
-        }
-
-        #[cfg(target_arch = "riscv32")]
-        {
-            let _args = core::mem::transmute(_args);
-            syslog(_level, _format as *const u8, _args);
-        }
-    }
+    let _args = core::mem::transmute(_args);
+    syslog(_level, _format as *const u8, _args);
 }
 
 /****************************************************************************


### PR DESCRIPTION
A not terribly complex patch to resolve #16. It might be easier to just bump MSRV, but 🤷‍♂️.

Also closes https://github.com/esp-rs/esp-mbedtls/issues/13