### PR TITLE
Fix typo in ble feature name

### DIFF
--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -247,7 +247,7 @@ pub fn initialize(
     radio_clocks: hal::system::RadioClockControl,
     clocks: &Clocks,
 ) -> Result<EspWifiInitialization, InitializationError> {
-    #[cfg(all(not(coex), feature = "wifi", feature = "bluetooth"))]
+    #[cfg(all(not(coex), feature = "wifi", feature = "ble"))]
     if init_for == EspWifiInitFor::WifiBle {
         panic!("Trying to use Wifi and BLE without COEX feature");
     }


### PR DESCRIPTION
The `initialize` function checks if wifi and ble are enable simultaneously without coex, but it was mistakenly using `feature = bluetooth` instead of `feature = ble`. This meant the check was actually never compiled in.