### PR TITLE
Misc. simplifications

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -594,7 +594,6 @@ pub fn wifi_init() -> Result<(), WifiError> {
     unsafe {
         G_CONFIG.wpa_crypto_funcs = g_wifi_default_wpa_crypto_funcs;
         G_CONFIG.feature_caps = g_wifi_feature_caps;
-        crate::wifi_set_log_verbose();
 
         #[cfg(coex)]
         {
@@ -604,7 +603,6 @@ pub fn wifi_init() -> Result<(), WifiError> {
         esp_wifi_result!(esp_wifi_init_internal(&G_CONFIG))?;
         esp_wifi_result!(esp_wifi_set_mode(wifi_mode_t_WIFI_MODE_NULL))?;
 
-        crate::wifi_set_log_verbose();
         esp_wifi_result!(esp_supplicant_init())?;
 
         esp_wifi_result!(esp_wifi_set_tx_done_cb(Some(esp_wifi_tx_done_cb)))?;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -740,7 +740,7 @@ pub fn wifi_start() -> Result<(), WifiError> {
         cntry_code[2] = crate::CONFIG.country_code_operating_class;
 
         let country = wifi_country_t {
-            cc: core::mem::transmute(cntry_code),
+            cc: core::mem::transmute(cntry_code), // [u8] -> [i8] conversion
             schan: 1,
             nchan: 13,
             max_tx_power: 20,

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1032,8 +1032,8 @@ where
         );
         let buffer = data.as_slice_mut();
         dump_packet_info(&buffer);
-        let res = f(buffer);
-        res
+
+        f(buffer)
     })
 }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod os_adapter;
+pub(crate) mod state;
 
 use atomic_polyfill::AtomicUsize;
 use core::sync::atomic::Ordering;
@@ -38,6 +39,8 @@ use num_traits::FromPrimitive;
 
 #[doc(hidden)]
 pub use os_adapter::*;
+pub use state::*;
+
 use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
 
 const ETHERNET_FRAME_HEADER_SIZE: usize = 18;
@@ -1458,8 +1461,8 @@ mod asynch {
             embedded_svc::wifi::Wifi::stop(self)?;
             WifiEventFuture::new(event).await;
 
-            AP_STATE.store(WifiState::Invalid, Ordering::Relaxed);
-            STA_STATE.store(WifiState::Invalid, Ordering::Relaxed);
+            reset_ap_state();
+            reset_sta_state();
 
             Ok(())
         }

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -956,7 +956,7 @@ impl<'d> WifiController<'d> {
 }
 
 // see https://docs.rs/smoltcp/0.7.1/smoltcp/phy/index.html
-impl<'d> Device for WifiDevice<'d> {
+impl Device for WifiDevice<'_> {
     type RxToken<'a> = WifiRxToken where Self: 'a;
     type TxToken<'a> = WifiTxToken where Self: 'a;
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -719,25 +719,20 @@ pub fn wifi_start() -> Result<(), WifiError> {
             ))?;
         };
 
+        let ps_mode;
         cfg_if::cfg_if! {
             if #[cfg(feature = "ps-min-modem")] {
-                esp_wifi_result!(esp_wifi_set_ps(
-                    include::wifi_ps_type_t_WIFI_PS_MIN_MODEM
-                ))?;
+                ps_mode = include::wifi_ps_type_t_WIFI_PS_MIN_MODEM;
             } else if #[cfg(feature = "ps-max-modem")] {
-                esp_wifi_result!(esp_wifi_set_ps(
-                    include::wifi_ps_type_t_WIFI_PS_MAX_MODEM
-                ))?;
+                ps_mode = include::wifi_ps_type_t_WIFI_PS_MAX_MODEM;
             } else if #[cfg(coex)] {
-                esp_wifi_result!(esp_wifi_set_ps(
-                    include::wifi_ps_type_t_WIFI_PS_MIN_MODEM
-                ))?;
+                ps_mode = include::wifi_ps_type_t_WIFI_PS_MIN_MODEM;
             } else {
-                esp_wifi_result!(esp_wifi_set_ps(
-                    include::wifi_ps_type_t_WIFI_PS_NONE
-                ))?;
+                ps_mode = include::wifi_ps_type_t_WIFI_PS_NONE;
             }
         };
+
+        esp_wifi_result!(esp_wifi_set_ps(ps_mode))?;
 
         let mut cntry_code = [0u8; 3];
         cntry_code[..crate::CONFIG.country_code.len()]

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -737,9 +737,7 @@ pub fn wifi_start() -> Result<(), WifiError> {
         let mut cntry_code = [0u8; 3];
         cntry_code[..crate::CONFIG.country_code.len()]
             .copy_from_slice(crate::CONFIG.country_code.as_bytes());
-        if crate::CONFIG.country_code_operating_class != 0 {
-            cntry_code[2] = crate::CONFIG.country_code_operating_class;
-        }
+        cntry_code[2] = crate::CONFIG.country_code_operating_class;
 
         let country = wifi_country_t {
             cc: core::mem::transmute(cntry_code),

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -798,13 +798,6 @@ pub fn new_with_mode<'d>(
     )
 }
 
-pub fn new<'d>(
-    inited: &EspWifiInitialization,
-    device: impl Peripheral<P = crate::hal::radio::Wifi> + 'd,
-) -> Result<(WifiDevice<'d>, WifiController<'d>), WifiError> {
-    new_with_config(&inited, device, Default::default())
-}
-
 /// A wifi device implementing smoltcp's Device trait.
 pub struct WifiDevice<'d> {
     _device: PeripheralRef<'d, crate::hal::radio::Wifi>,

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1,5 +1,4 @@
-#[doc(hidden)]
-pub mod os_adapter;
+pub(crate) mod os_adapter;
 
 use atomic_polyfill::AtomicUsize;
 use core::sync::atomic::Ordering;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1243,12 +1243,11 @@ impl Wifi for WifiController<'_> {
     }
 }
 
-#[allow(unreachable_code, unused_variables)]
-fn dump_packet_info(buffer: &[u8]) {
-    #[cfg(not(feature = "dump-packets"))]
-    return;
-
-    info!("@WIFIFRAME {:?}", buffer);
+fn dump_packet_info(_buffer: &[u8]) {
+    #[cfg(feature = "dump-packets")]
+    {
+        info!("@WIFIFRAME {:?}", _buffer);
+    }
 }
 
 #[macro_export]

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1483,7 +1483,7 @@ mod asynch {
             if clear_pending {
                 Self::clear_events(events);
             }
-            MultiWifiEventFuture::new(EnumSet::from(events)).await
+            MultiWifiEventFuture::new(events).await
         }
     }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1080,8 +1080,9 @@ pub fn esp_wifi_send_data(interface: wifi_interface_t, data: &mut [u8]) {
         let _res = esp_wifi_internal_tx(interface, ptr, len);
         if _res != 0 {
             warn!("esp_wifi_internal_tx {}", _res);
+        } else {
+            trace!("esp_wifi_internal_tx {}", _res);
         }
-        trace!("esp_wifi_internal_tx {}", _res);
     }
 }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -6,7 +6,7 @@ use core::ptr::addr_of;
 use core::sync::atomic::Ordering;
 use core::{cell::RefCell, mem::MaybeUninit};
 
-use crate::common_adapter::{self, *};
+use crate::common_adapter::*;
 use crate::esp_wifi_result;
 use crate::hal::macros::ram;
 use crate::hal::peripheral::Peripheral;
@@ -335,7 +335,7 @@ unsafe extern "C" fn semphr_take_from_isr_wrapper(
     semphr: *mut c_types::c_void,
     hptw: *mut c_types::c_void,
 ) -> i32 {
-    common_adapter::semphr_take_from_isr(semphr as *const (), hptw as *const ())
+    crate::common_adapter::semphr_take_from_isr(semphr as *const (), hptw as *const ())
 }
 
 #[cfg(coex)]
@@ -343,7 +343,7 @@ unsafe extern "C" fn semphr_give_from_isr_wrapper(
     semphr: *mut c_types::c_void,
     hptw: *mut c_types::c_void,
 ) -> i32 {
-    common_adapter::semphr_give_from_isr(semphr as *const (), hptw as *const ())
+    crate::common_adapter::semphr_give_from_isr(semphr as *const (), hptw as *const ())
 }
 
 #[cfg(coex)]

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -858,6 +858,9 @@ impl<'d> WifiController<'d> {
         _device: PeripheralRef<'d, crate::hal::radio::Wifi>,
         config: embedded_svc::wifi::Configuration,
     ) -> Result<Self, WifiError> {
+        // We set up the controller with the default config because we need to call
+        // `set_configuration` to apply the actual configuration, and it will update the stored
+        // configuration anyway.
         let mut this = Self {
             _device,
             config: Default::default(),

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -7,9 +7,7 @@
 pub(crate) mod os_adapter_chip_specific;
 
 use core::cell::RefCell;
-use core::sync::atomic::Ordering;
 
-use atomic_enum::atomic_enum;
 use critical_section::Mutex;
 use enumset::EnumSet;
 
@@ -34,57 +32,9 @@ use crate::compat::common::syslog;
 
 use super::WifiEvent;
 
-pub(crate) static STA_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::Invalid);
-pub(crate) static AP_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::Invalid);
-
 // useful for waiting for events - clear and wait for the event bit to be set again
 pub(crate) static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
     Mutex::new(RefCell::new(enumset::enum_set!()));
-
-#[atomic_enum]
-#[derive(PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum WifiState {
-    StaStarted,
-    StaConnected,
-    StaDisconnected,
-    StaStopped,
-
-    ApStarted,
-    ApStopped,
-
-    Invalid,
-}
-
-impl From<WifiEvent> for WifiState {
-    fn from(event: WifiEvent) -> WifiState {
-        match event {
-            WifiEvent::StaStart => WifiState::StaStarted,
-            WifiEvent::StaConnected => WifiState::StaConnected,
-            WifiEvent::StaDisconnected => WifiState::StaDisconnected,
-            WifiEvent::StaStop => WifiState::StaStopped,
-            WifiEvent::ApStart => WifiState::ApStarted,
-            WifiEvent::ApStop => WifiState::ApStopped,
-            _ => WifiState::Invalid,
-        }
-    }
-}
-
-pub fn get_ap_state() -> WifiState {
-    AP_STATE.load(Ordering::Relaxed)
-}
-
-pub fn get_sta_state() -> WifiState {
-    STA_STATE.load(Ordering::Relaxed)
-}
-
-pub fn get_wifi_state() -> WifiState {
-    match super::get_wifi_mode() {
-        Ok(super::WifiMode::Sta) => get_sta_state(),
-        Ok(super::WifiMode::Ap) => get_ap_state(),
-        _ => WifiState::Invalid,
-    }
-}
 
 /****************************************************************************
  * Name: wifi_env_is_chip
@@ -934,16 +884,7 @@ pub unsafe extern "C" fn event_post(
     trace!("EVENT: {:?}", event);
     critical_section::with(|cs| WIFI_EVENTS.borrow_ref_mut(cs).insert(event));
 
-    match event {
-        WifiEvent::StaConnected
-        | WifiEvent::StaDisconnected
-        | WifiEvent::StaStart
-        | WifiEvent::StaStop => STA_STATE.store(WifiState::from(event), Ordering::Relaxed),
-        WifiEvent::ApStart | WifiEvent::ApStop => {
-            AP_STATE.store(WifiState::from(event), Ordering::Relaxed)
-        }
-        other => debug!("Unhandled event: {:?}", other),
-    }
+    super::state::update_state(event);
 
     #[cfg(feature = "async")]
     event.waker().wake();

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -41,10 +41,6 @@ pub(crate) static AP_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::In
 pub(crate) static WIFI_EVENTS: Mutex<RefCell<EnumSet<WifiEvent>>> =
     Mutex::new(RefCell::new(enumset::enum_set!()));
 
-pub fn is_connected() -> bool {
-    get_sta_state() == WifiState::StaConnected
-}
-
 #[atomic_enum]
 #[derive(PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/esp-wifi/src/wifi/state.rs
+++ b/esp-wifi/src/wifi/state.rs
@@ -68,6 +68,9 @@ pub(crate) fn reset_sta_state() {
     STA_STATE.store(WifiState::Invalid, Ordering::Relaxed)
 }
 
+/// Returns the current state of the WiFi stack.
+///
+/// This does not support AP-STA mode. Use one of `get_sta_state` or `get_ap_state` instead.
 pub fn get_wifi_state() -> WifiState {
     use super::WifiMode;
     match WifiMode::current() {

--- a/esp-wifi/src/wifi/state.rs
+++ b/esp-wifi/src/wifi/state.rs
@@ -1,0 +1,77 @@
+use super::WifiEvent;
+
+use atomic_enum::atomic_enum;
+use core::sync::atomic::Ordering;
+
+#[atomic_enum]
+#[derive(PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WifiState {
+    StaStarted,
+    StaConnected,
+    StaDisconnected,
+    StaStopped,
+
+    ApStarted,
+    ApStopped,
+
+    Invalid,
+}
+
+impl From<WifiEvent> for WifiState {
+    fn from(event: WifiEvent) -> WifiState {
+        match event {
+            WifiEvent::StaStart => WifiState::StaStarted,
+            WifiEvent::StaConnected => WifiState::StaConnected,
+            WifiEvent::StaDisconnected => WifiState::StaDisconnected,
+            WifiEvent::StaStop => WifiState::StaStopped,
+            WifiEvent::ApStart => WifiState::ApStarted,
+            WifiEvent::ApStop => WifiState::ApStopped,
+            _ => WifiState::Invalid,
+        }
+    }
+}
+
+pub(crate) static STA_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::Invalid);
+pub(crate) static AP_STATE: AtomicWifiState = AtomicWifiState::new(WifiState::Invalid);
+
+pub fn get_ap_state() -> WifiState {
+    AP_STATE.load(Ordering::Relaxed)
+}
+
+pub fn get_sta_state() -> WifiState {
+    STA_STATE.load(Ordering::Relaxed)
+}
+
+pub(crate) fn update_state(event: WifiEvent) {
+    match event {
+        WifiEvent::StaConnected
+        | WifiEvent::StaDisconnected
+        | WifiEvent::StaStart
+        | WifiEvent::StaStop => STA_STATE.store(WifiState::from(event), Ordering::Relaxed),
+
+        WifiEvent::ApStart | WifiEvent::ApStop => {
+            AP_STATE.store(WifiState::from(event), Ordering::Relaxed)
+        }
+
+        other => debug!("Unhandled event: {:?}", other),
+    }
+}
+
+#[cfg(feature = "async")]
+pub(crate) fn reset_ap_state() {
+    AP_STATE.store(WifiState::Invalid, Ordering::Relaxed)
+}
+
+#[cfg(feature = "async")]
+pub(crate) fn reset_sta_state() {
+    STA_STATE.store(WifiState::Invalid, Ordering::Relaxed)
+}
+
+pub fn get_wifi_state() -> WifiState {
+    match super::get_wifi_mode() {
+        Ok(super::WifiMode::Sta) => get_sta_state(),
+        Ok(super::WifiMode::Ap) => get_ap_state(),
+        _ => WifiState::Invalid,
+    }
+}

--- a/esp-wifi/src/wifi/state.rs
+++ b/esp-wifi/src/wifi/state.rs
@@ -69,9 +69,10 @@ pub(crate) fn reset_sta_state() {
 }
 
 pub fn get_wifi_state() -> WifiState {
-    match super::get_wifi_mode() {
-        Ok(super::WifiMode::Sta) => get_sta_state(),
-        Ok(super::WifiMode::Ap) => get_ap_state(),
+    use super::WifiMode;
+    match WifiMode::current() {
+        Ok(WifiMode::Sta) => get_sta_state(),
+        Ok(WifiMode::Ap) => get_ap_state(),
         _ => WifiState::Invalid,
     }
 }


### PR DESCRIPTION
Includes some preparatory changes towards AP-STA mode, but mostly just cleanups, and I've also removed a public constructor that has no other option but to panic (as the default Configuration value is None). AP-STA code changes set_configuration so it can no longer change the type of the configuration, which makes a None constructor somewhat useless.

Due to its size, I recommend going through the changes one commit at a time.