### PR TITLE
AP-STA mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: cd esp-wifi && cargo b${{ matrix.chip }} --features=async,wifi,esp-now,embassy-net,log,${{ matrix.chip }}-hal/embassy-time-timg0
       - name: build (common features + defmt)
         run: cd esp-wifi && cargo b${{ matrix.chip }} --no-default-features --features=async,wifi,esp-now,embassy-net,defmt,${{ matrix.chip }}-hal/embassy-time-timg0
+      - name: build (access_point)
+        run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=access_point --features=wifi
+      - name: build (access_point_with_sta)
+        run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=access_point_with_sta --features=wifi
       - name: build (dhcp)
         run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=dhcp --features=wifi
       - name: build (bench)
@@ -81,6 +85,8 @@ jobs:
         run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=embassy_bench --features=async,wifi,embassy-net,${{ matrix.chip }}-hal/embassy-time-timg0
       - name: build (embassy_access_point)
         run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=embassy_access_point --features=async,wifi,embassy-net,${{ matrix.chip }}-hal/embassy-time-timg0
+      - name: build (embassy_access_point_with_sta)
+        run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=embassy_access_point_with_sta --features=async,wifi,embassy-net,${{ matrix.chip }}-hal/embassy-time-timg0
 
       - name: build (common features + ble)
         if: ${{ matrix.chip != 'esp32s2' }}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ See [Examples] for details.
 ## Missing / To be done
 
 - Make CoEx work on ESP32 (it kind of works when commenting out setting the country in wifi_start, probably some mis-compilation since it then crashes in a totally different code path)
-- Combined SoftAP/STA mode
 - Support for non-open SoftAP
 - Direct-boot mode isn't supported
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,6 +91,17 @@ cargo esp32c3 --release ...
 
 `cargo $CHIP --example access_point --release --features "embedded-svc,wifi"`
 
+### access_point_with_sta
+
+- set SSID and PASSWORD env variable
+- gets an ip address via DHCP
+- creates an open access-point with SSID `esp-wifi`
+- you can connect to it using a static IP in range 192.168.2.2 .. 192.168.2.255, gateway 192.168.2.1
+- open http://192.168.2.1:8080/ in your browser - the example will perform an HTTP get request to some "random" server
+- on Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
+
+`cargo $CHIP --example access_point_with_sta --release --features "embedded-svc,wifi"`
+
 ### embassy_access_point
 
 - creates an open access-point with SSID `esp-wifi`
@@ -99,6 +110,17 @@ cargo esp32c3 --release ...
 - on Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
 
 `cargo $CHIP --example embassy_access_point --release --features "async,embedded-svc,wifi,embassy-net"`
+
+### embassy_access_point_with_sta
+
+- set SSID and PASSWORD env variable
+- gets an ip address via DHCP
+- creates an open access-point with SSID `esp-wifi`
+- you can connect to it using a static IP in range 192.168.2.2 .. 192.168.2.255, gateway 192.168.2.1
+- open http://192.168.2.1:8080/ in your browser - the example will perform an HTTP get request to some "random" server
+- on Android you might need to choose _Keep Accesspoint_ when it tells you the WiFi has no internet connection, Chrome might not want to load the URL - you can use a shell and try `curl` and `ping`
+
+`cargo $CHIP --example embassy_access_point_with_sta --release --features "async,embedded-svc,wifi,embassy-net"`
 
 ## Benchmarking
 

--- a/esp-wifi/examples/access_point.rs
+++ b/esp-wifi/examples/access_point.rs
@@ -13,7 +13,7 @@ use esp_backtrace as _;
 use esp_println::{print, println};
 use esp_wifi::initialize;
 use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi::WifiMode;
+use esp_wifi::wifi::WifiApDevice;
 use esp_wifi::wifi_interface::WifiStack;
 use esp_wifi::{current_millis, EspWifiInitFor};
 use hal::clock::ClockControl;
@@ -48,7 +48,7 @@ fn main() -> ! {
     let wifi = peripherals.WIFI;
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Ap, &mut socket_set_entries).unwrap();
+        create_network_interface(&init, wifi, WifiApDevice, &mut socket_set_entries).unwrap();
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::AccessPoint(AccessPointConfiguration {

--- a/esp-wifi/examples/access_point_with_sta.rs
+++ b/esp-wifi/examples/access_point_with_sta.rs
@@ -1,0 +1,224 @@
+#![no_std]
+#![no_main]
+
+#[path = "../../examples-util/util.rs"]
+mod examples_util;
+use examples_util::hal;
+
+use embedded_io::*;
+use embedded_svc::ipv4::Interface;
+use embedded_svc::wifi::{AccessPointConfiguration, ClientConfiguration, Configuration, Wifi};
+
+use esp_backtrace as _;
+use esp_println::{print, println};
+use esp_wifi::initialize;
+use esp_wifi::wifi::utils::{create_ap_sta_network_interface, ApStaInterface};
+use esp_wifi::wifi_interface::WifiStack;
+use esp_wifi::{current_millis, EspWifiInitFor};
+use hal::clock::ClockControl;
+use hal::Rng;
+use hal::{peripherals::Peripherals, prelude::*};
+
+use smoltcp::iface::SocketStorage;
+use smoltcp::wire::IpAddress;
+use smoltcp::wire::Ipv4Address;
+
+const SSID: &str = env!("SSID");
+const PASSWORD: &str = env!("PASSWORD");
+
+#[entry]
+fn main() -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::max(system.clock_control).freeze();
+
+    #[cfg(target_arch = "xtensa")]
+    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = peripherals.WIFI;
+
+    let mut ap_socket_set_entries: [SocketStorage; 3] = Default::default();
+    let mut sta_socket_set_entries: [SocketStorage; 3] = Default::default();
+
+    let ApStaInterface {
+        ap_interface,
+        sta_interface,
+        ap_device,
+        sta_device,
+        mut controller,
+        ap_socket_set,
+        sta_socket_set,
+    } = create_ap_sta_network_interface(
+        &init,
+        wifi,
+        &mut ap_socket_set_entries,
+        &mut sta_socket_set_entries,
+    )
+    .unwrap();
+
+    let mut wifi_ap_stack = WifiStack::new(ap_interface, ap_device, ap_socket_set, current_millis);
+    let wifi_sta_stack = WifiStack::new(sta_interface, sta_device, sta_socket_set, current_millis);
+
+    let client_config = Configuration::Mixed(
+        ClientConfiguration {
+            ssid: SSID.into(),
+            password: PASSWORD.into(),
+            ..Default::default()
+        },
+        AccessPointConfiguration {
+            ssid: "esp-wifi".into(),
+            ..Default::default()
+        },
+    );
+    let res = controller.set_configuration(&client_config);
+    println!("wifi_set_configuration returned {:?}", res);
+
+    controller.start().unwrap();
+    println!("is wifi started: {:?}", controller.is_started());
+
+    println!("{:?}", controller.get_capabilities());
+
+    wifi_ap_stack
+        .set_iface_configuration(&embedded_svc::ipv4::Configuration::Client(
+            embedded_svc::ipv4::ClientConfiguration::Fixed(embedded_svc::ipv4::ClientSettings {
+                ip: embedded_svc::ipv4::Ipv4Addr::from(parse_ip("192.168.2.1")),
+                subnet: embedded_svc::ipv4::Subnet {
+                    gateway: embedded_svc::ipv4::Ipv4Addr::from(parse_ip("192.168.2.1")),
+                    mask: embedded_svc::ipv4::Mask(24),
+                },
+                dns: None,
+                secondary_dns: None,
+            }),
+        ))
+        .unwrap();
+
+    println!("wifi_connect {:?}", controller.connect());
+
+    // wait for STA getting an ip address
+    println!("Wait to get an ip address");
+    loop {
+        wifi_sta_stack.work();
+
+        if wifi_sta_stack.is_iface_up() {
+            println!("got ip {:?}", wifi_sta_stack.get_ip_info());
+            break;
+        }
+    }
+
+    println!("Start busy loop on main. Connect to the AP `esp-wifi` and point your browser to http://192.168.2.1:8080/");
+    println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
+
+    let mut rx_buffer = [0u8; 1536];
+    let mut tx_buffer = [0u8; 1536];
+    let mut ap_socket = wifi_ap_stack.get_socket(&mut rx_buffer, &mut tx_buffer);
+
+    let mut sta_rx_buffer = [0u8; 1536];
+    let mut sta_tx_buffer = [0u8; 1536];
+    let mut sta_socket = wifi_sta_stack.get_socket(&mut sta_rx_buffer, &mut sta_tx_buffer);
+
+    ap_socket.listen(8080).unwrap();
+
+    loop {
+        ap_socket.work();
+
+        if !ap_socket.is_open() {
+            ap_socket.listen(8080).unwrap();
+        }
+
+        if ap_socket.is_connected() {
+            println!("Connected");
+
+            let mut time_out = false;
+            let wait_end = current_millis() + 20 * 1000;
+            let mut buffer = [0u8; 1024];
+            let mut pos = 0;
+            loop {
+                if let Ok(len) = ap_socket.read(&mut buffer[pos..]) {
+                    let to_print =
+                        unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
+
+                    if to_print.contains("\r\n\r\n") {
+                        print!("{}", to_print);
+                        println!();
+                        break;
+                    }
+
+                    pos += len;
+                } else {
+                    break;
+                }
+
+                if current_millis() > wait_end {
+                    println!("Timeout");
+                    time_out = true;
+                    break;
+                }
+            }
+
+            if !time_out {
+                println!("Making HTTP request");
+                sta_socket.work();
+
+                sta_socket
+                    .open(IpAddress::Ipv4(Ipv4Address::new(142, 250, 185, 115)), 80)
+                    .unwrap();
+
+                sta_socket
+                    .write(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
+                    .unwrap();
+                sta_socket.flush().unwrap();
+
+                let wait_end = current_millis() + 20 * 1000;
+                loop {
+                    let mut buffer = [0u8; 512];
+                    if let Ok(len) = sta_socket.read(&mut buffer) {
+                        ap_socket.write_all(&buffer[..len]).unwrap();
+                        ap_socket.flush().unwrap();
+                    } else {
+                        break;
+                    }
+
+                    if current_millis() > wait_end {
+                        println!("Timeout");
+                        break;
+                    }
+                }
+                println!();
+
+                sta_socket.disconnect();
+            }
+
+            ap_socket.close();
+
+            println!("Done\n");
+            println!();
+        }
+
+        let wait_end = current_millis() + 5 * 1000;
+        while current_millis() < wait_end {
+            ap_socket.work();
+        }
+    }
+}
+
+fn parse_ip(ip: &str) -> [u8; 4] {
+    let mut result = [0u8; 4];
+    for (idx, octet) in ip.split(".").into_iter().enumerate() {
+        result[idx] = u8::from_str_radix(octet, 10).unwrap();
+    }
+    result
+}

--- a/esp-wifi/examples/bench.rs
+++ b/esp-wifi/examples/bench.rs
@@ -12,7 +12,7 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::println;
 use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi::{WifiError, WifiMode};
+use esp_wifi::wifi::{WifiError, WifiStaDevice};
 use esp_wifi::wifi_interface::WifiStack;
 use esp_wifi::{current_millis, initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
@@ -62,7 +62,7 @@ fn main() -> ! {
     let wifi = peripherals.WIFI;
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
+        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
@@ -137,7 +137,7 @@ fn main() -> ! {
 
 fn test_download<'a>(
     server_address: Ipv4Address,
-    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a>,
+    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a, WifiStaDevice>,
 ) {
     println!("Testing download...");
     socket.work();
@@ -171,7 +171,7 @@ fn test_download<'a>(
 
 fn test_upload<'a>(
     server_address: Ipv4Address,
-    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a>,
+    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a, WifiStaDevice>,
 ) {
     println!("Testing upload...");
     socket.work();
@@ -205,7 +205,7 @@ fn test_upload<'a>(
 
 fn test_upload_download<'a>(
     server_address: Ipv4Address,
-    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a>,
+    socket: &mut esp_wifi::wifi_interface::Socket<'a, 'a, WifiStaDevice>,
 ) {
     println!("Testing upload+download...");
     socket.work();

--- a/esp-wifi/examples/coex.rs
+++ b/esp-wifi/examples/coex.rs
@@ -14,7 +14,7 @@ use bleps::{
 };
 
 use esp_wifi::{
-    ble::controller::BleConnector, current_millis, wifi::WifiMode, wifi_interface::WifiStack,
+    ble::controller::BleConnector, current_millis, wifi::WifiStaDevice, wifi_interface::WifiStack,
     EspWifiInitFor,
 };
 
@@ -61,7 +61,7 @@ fn main() -> ! {
 
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
+        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -12,7 +12,7 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::{print, println};
 use esp_wifi::wifi::utils::create_network_interface;
-use esp_wifi::wifi::{WifiError, WifiMode};
+use esp_wifi::wifi::{WifiError, WifiStaDevice};
 use esp_wifi::wifi_interface::WifiStack;
 use esp_wifi::{current_millis, initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
@@ -51,7 +51,7 @@ fn main() -> ! {
     let wifi = peripherals.WIFI;
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
+        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {

--- a/esp-wifi/examples/embassy_access_point.rs
+++ b/esp-wifi/examples/embassy_access_point.rs
@@ -71,8 +71,8 @@ async fn main(spawner: Spawner) -> ! {
     spawner.spawn(connection(controller)).ok();
     spawner.spawn(net_task(&stack)).ok();
 
-    let mut rx_buffer = [0; 4096];
-    let mut tx_buffer = [0; 4096];
+    let mut rx_buffer = [0; 1536];
+    let mut tx_buffer = [0; 1536];
 
     loop {
         if stack.is_link_up() {

--- a/esp-wifi/examples/embassy_access_point.rs
+++ b/esp-wifi/examples/embassy_access_point.rs
@@ -15,7 +15,7 @@ use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{AccessPointConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_println::{print, println};
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::wifi::{WifiApDevice, WifiController, WifiDevice, WifiEvent, WifiState};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -47,7 +47,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Ap).unwrap();
+        esp_wifi::wifi::new_with_mode(&init, wifi, WifiApDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
@@ -184,6 +184,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static>>) {
+async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiApDevice>>) {
     stack.run().await
 }

--- a/esp-wifi/examples/embassy_access_point_with_sta.rs
+++ b/esp-wifi/examples/embassy_access_point_with_sta.rs
@@ -1,0 +1,302 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use embassy_net::tcp::TcpSocket;
+use embassy_net::{
+    Config, IpListenEndpoint, Ipv4Address, Ipv4Cidr, Stack, StackResources, StaticConfigV4,
+};
+#[path = "../../examples-util/util.rs"]
+mod examples_util;
+use examples_util::hal;
+
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
+use embedded_svc::wifi::{AccessPointConfiguration, ClientConfiguration, Configuration, Wifi};
+use esp_backtrace as _;
+use esp_println::{print, println};
+use esp_wifi::wifi::{
+    WifiApDevice, WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState,
+};
+use esp_wifi::{initialize, EspWifiInitFor};
+use hal::clock::ClockControl;
+use hal::Rng;
+use hal::{embassy, peripherals::Peripherals, prelude::*, timer::TimerGroup};
+use static_cell::make_static;
+
+const SSID: &str = env!("SSID");
+const PASSWORD: &str = env!("PASSWORD");
+
+#[main]
+async fn main(spawner: Spawner) -> ! {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+
+    let peripherals = Peripherals::take();
+
+    let system = peripherals.SYSTEM.split();
+    let clocks = ClockControl::max(system.clock_control).freeze();
+
+    #[cfg(target_arch = "xtensa")]
+    let timer = hal::timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    #[cfg(target_arch = "riscv32")]
+    let timer = hal::systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+
+    let wifi = peripherals.WIFI;
+    let (wifi_ap_interface, wifi_sta_interface, mut controller) =
+        esp_wifi::wifi::new_ap_sta(&init, wifi).unwrap();
+
+    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    embassy::init(&clocks, timer_group0.timer0);
+
+    let ap_config = Config::ipv4_static(StaticConfigV4 {
+        address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
+        gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
+        dns_servers: Default::default(),
+    });
+    let sta_config = Config::dhcpv4(Default::default());
+
+    let seed = 1234; // very random, very secure seed
+
+    // Init network stacks
+    let ap_stack = &*make_static!(Stack::new(
+        wifi_ap_interface,
+        ap_config,
+        make_static!(StackResources::<3>::new()),
+        seed
+    ));
+    let sta_stack = &*make_static!(Stack::new(
+        wifi_sta_interface,
+        sta_config,
+        make_static!(StackResources::<3>::new()),
+        seed
+    ));
+
+    let client_config = Configuration::Mixed(
+        ClientConfiguration {
+            ssid: SSID.into(),
+            password: PASSWORD.into(),
+            ..Default::default()
+        },
+        AccessPointConfiguration {
+            ssid: "esp-wifi".into(),
+            ..Default::default()
+        },
+    );
+    controller.set_configuration(&client_config).unwrap();
+
+    spawner.spawn(connection(controller)).ok();
+    spawner.spawn(ap_task(&ap_stack)).ok();
+    spawner.spawn(sta_task(&sta_stack)).ok();
+
+    loop {
+        if sta_stack.is_link_up() {
+            break;
+        }
+        println!("Waiting for IP...");
+        Timer::after(Duration::from_millis(500)).await;
+    }
+    loop {
+        if ap_stack.is_link_up() {
+            break;
+        }
+        Timer::after(Duration::from_millis(500)).await;
+    }
+    println!("Connect to the AP `esp-wifi` and point your browser to http://192.168.2.1:8080/");
+    println!("Use a static IP in the range 192.168.2.2 .. 192.168.2.255, use gateway 192.168.2.1");
+
+    let mut ap_rx_buffer = [0; 1536];
+    let mut ap_tx_buffer = [0; 1536];
+
+    let mut ap_socket = TcpSocket::new(&ap_stack, &mut ap_rx_buffer, &mut ap_tx_buffer);
+    ap_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+
+    let mut sta_rx_buffer = [0; 1536];
+    let mut sta_tx_buffer = [0; 1536];
+
+    let mut sta_socket = TcpSocket::new(&sta_stack, &mut sta_rx_buffer, &mut sta_tx_buffer);
+    sta_socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+
+    loop {
+        println!("Wait for connection...");
+        let r = ap_socket
+            .accept(IpListenEndpoint {
+                addr: None,
+                port: 8080,
+            })
+            .await;
+        println!("Connected...");
+
+        if let Err(e) = r {
+            println!("connect error: {:?}", e);
+            continue;
+        }
+
+        use embedded_io_async::Write;
+
+        let mut buffer = [0u8; 1024];
+        let mut pos = 0;
+        loop {
+            match ap_socket.read(&mut buffer).await {
+                Ok(0) => {
+                    println!("AP read EOF");
+                    break;
+                }
+                Ok(len) => {
+                    let to_print =
+                        unsafe { core::str::from_utf8_unchecked(&buffer[..(pos + len)]) };
+
+                    if to_print.contains("\r\n\r\n") {
+                        print!("{}", to_print);
+                        println!();
+                        break;
+                    }
+
+                    pos += len;
+                }
+                Err(e) => {
+                    println!("AP read error: {:?}", e);
+                    break;
+                }
+            };
+        }
+
+        if sta_stack.is_link_up() {
+            let remote_endpoint = (Ipv4Address::new(142, 250, 185, 115), 80);
+            println!("connecting...");
+            let r = sta_socket.connect(remote_endpoint).await;
+            if let Err(e) = r {
+                println!("STA connect error: {:?}", e);
+                continue;
+            }
+
+            use embedded_io_async::Write;
+            let r = sta_socket
+                .write_all(b"GET / HTTP/1.0\r\nHost: www.mobile-j.de\r\n\r\n")
+                .await;
+
+            if let Err(e) = r {
+                println!("STA write error: {:?}", e);
+
+                let r = ap_socket
+                    .write_all(
+                        b"HTTP/1.0 500 Internal Server Error\r\n\r\n\
+                        <html>\
+                            <body>\
+                                <h1>Hello Rust! Hello esp-wifi! STA failed to send request.</h1>\
+                            </body>\
+                        </html>\r\n\
+                        ",
+                    )
+                    .await;
+                if let Err(e) = r {
+                    println!("AP write error: {:?}", e);
+                }
+            } else {
+                let r = sta_socket.flush().await;
+                if let Err(e) = r {
+                    println!("STA flush error: {:?}", e);
+                } else {
+                    println!("connected!");
+                    let mut buf = [0; 1024];
+                    loop {
+                        match sta_socket.read(&mut buf).await {
+                            Ok(0) => {
+                                println!("STA read EOF");
+                                break;
+                            }
+                            Ok(n) => {
+                                let r = ap_socket.write_all(&buf[..n]).await;
+                                if let Err(e) = r {
+                                    println!("AP write error: {:?}", e);
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                println!("STA read error: {:?}", e);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            sta_socket.close();
+        } else {
+            let r = ap_socket
+                .write_all(
+                    b"HTTP/1.0 200 OK\r\n\r\n\
+                    <html>\
+                        <body>\
+                            <h1>Hello Rust! Hello esp-wifi! STA is not connected.</h1>\
+                        </body>\
+                    </html>\r\n\
+                    ",
+                )
+                .await;
+            if let Err(e) = r {
+                println!("AP write error: {:?}", e);
+            }
+        }
+
+        let r = ap_socket.flush().await;
+        if let Err(e) = r {
+            println!("AP flush error: {:?}", e);
+        }
+        Timer::after(Duration::from_millis(1000)).await;
+
+        ap_socket.close();
+        Timer::after(Duration::from_millis(1000)).await;
+
+        ap_socket.abort();
+    }
+}
+
+#[embassy_executor::task]
+async fn connection(mut controller: WifiController<'static>) {
+    println!("start connection task");
+    println!("Device capabilities: {:?}", controller.get_capabilities());
+
+    println!("Starting wifi");
+    controller.start().await.unwrap();
+    println!("Wifi started!");
+
+    loop {
+        match esp_wifi::wifi::get_ap_state() {
+            WifiState::ApStarted => {
+                println!("About to connect...");
+
+                match controller.connect().await {
+                    Ok(_) => {
+                        // wait until we're no longer connected
+                        controller.wait_for_event(WifiEvent::StaDisconnected).await;
+                        println!("STA disconnected");
+                    }
+                    Err(e) => {
+                        println!("Failed to connect to wifi: {e:?}");
+                        Timer::after(Duration::from_millis(5000)).await
+                    }
+                }
+            }
+            _ => return,
+        }
+    }
+}
+
+#[embassy_executor::task]
+async fn ap_task(stack: &'static Stack<WifiDevice<'static, WifiApDevice>>) {
+    stack.run().await
+}
+
+#[embassy_executor::task]
+async fn sta_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
+    stack.run().await
+}

--- a/esp-wifi/examples/embassy_bench.rs
+++ b/esp-wifi/examples/embassy_bench.rs
@@ -14,7 +14,7 @@ use embassy_time::{with_timeout, Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_println::println;
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::wifi::{WifiApDevice, WifiController, WifiDevice, WifiEvent, WifiState};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -60,7 +60,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta).unwrap();
+        esp_wifi::wifi::new_with_mode(&init, wifi, WifiApDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
@@ -146,7 +146,7 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static>>) {
+async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiApDevice>>) {
     stack.run().await
 }
 

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -13,7 +13,7 @@ use embassy_time::{Duration, Timer};
 use embedded_svc::wifi::{ClientConfiguration, Configuration, Wifi};
 use esp_backtrace as _;
 use esp_println::println;
-use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiMode, WifiState};
+use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiStaDevice, WifiState};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -48,7 +48,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiMode::Sta).unwrap();
+        esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0.timer0);
@@ -166,6 +166,6 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static>>) {
+async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
     stack.run().await
 }

--- a/esp-wifi/examples/static_ip.rs
+++ b/esp-wifi/examples/static_ip.rs
@@ -12,7 +12,7 @@ use embedded_svc::wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wi
 use esp_backtrace as _;
 use esp_println::{print, println};
 use esp_wifi::initialize;
-use esp_wifi::wifi::WifiMode;
+use esp_wifi::wifi::WifiStaDevice;
 use esp_wifi::wifi::{utils::create_network_interface, WifiError};
 use esp_wifi::wifi_interface::WifiStack;
 use esp_wifi::{current_millis, EspWifiInitFor};
@@ -53,7 +53,7 @@ fn main() -> ! {
     let wifi = peripherals.WIFI;
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
+        create_network_interface(&init, wifi, WifiStaDevice, &mut socket_set_entries).unwrap();
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1061,7 +1061,7 @@ impl WifiDeviceMode {
             if !rx.is_empty() {
                 self.tx_token().map(|tx| (WifiRxToken { mode: self }, tx))
             } else {
-                warn!("no Rx token available");
+                trace!("no Rx token available");
                 None
             }
         })

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -112,6 +112,7 @@ impl AuthMethodExt for AuthMethod {
 pub enum WifiMode {
     Sta,
     Ap,
+    ApSta,
 }
 
 impl WifiMode {
@@ -125,7 +126,7 @@ impl WifiMode {
     /// Returns true if this mode is STA
     pub fn is_sta(&self) -> bool {
         match self {
-            WifiMode::Sta => true,
+            WifiMode::Sta | WifiMode::ApSta => true,
             WifiMode::Ap => false,
         }
     }
@@ -134,7 +135,7 @@ impl WifiMode {
     pub fn is_ap(&self) -> bool {
         match self {
             WifiMode::Sta => false,
-            WifiMode::Ap => true,
+            WifiMode::Ap | WifiMode::ApSta => true,
         }
     }
 }
@@ -147,6 +148,7 @@ impl TryFrom<wifi_mode_t> for WifiMode {
         match value {
             include::wifi_mode_t_WIFI_MODE_STA => Ok(WifiMode::Sta),
             include::wifi_mode_t_WIFI_MODE_AP => Ok(WifiMode::Ap),
+            include::wifi_mode_t_WIFI_MODE_APSTA => Ok(WifiMode::ApSta),
             _ => Err(WifiError::UnknownWifiMode),
         }
     }
@@ -158,6 +160,7 @@ impl Into<wifi_mode_t> for WifiMode {
         match self {
             WifiMode::Sta => wifi_mode_t_WIFI_MODE_STA,
             WifiMode::Ap => wifi_mode_t_WIFI_MODE_AP,
+            WifiMode::ApSta => wifi_mode_t_WIFI_MODE_APSTA,
         }
     }
 }
@@ -915,6 +918,7 @@ pub fn new_with_config<'d>(
 
     crate::hal::into_ref!(device);
 
+    // TODO: we'll need two devices for AP-STA mode
     Ok((
         WifiDevice::new(unsafe { device.clone_unchecked() }),
         WifiController::new_with_config(device, config)?,
@@ -933,6 +937,9 @@ pub fn new_with_mode<'d>(
         match mode {
             WifiMode::Sta => embedded_svc::wifi::Configuration::Client(Default::default()),
             WifiMode::Ap => embedded_svc::wifi::Configuration::AccessPoint(Default::default()),
+            WifiMode::ApSta => {
+                embedded_svc::wifi::Configuration::Mixed(Default::default(), Default::default())
+            }
         },
     )
 }

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1064,15 +1064,14 @@ impl WifiDeviceMode {
     }
 
     fn rx_token(self) -> Option<(WifiRxToken, WifiTxToken)> {
-        critical_section::with(|cs| {
-            let rx = self.data_queue_rx(cs);
-            if !rx.is_empty() {
-                self.tx_token().map(|tx| (WifiRxToken { mode: self }, tx))
-            } else {
-                trace!("no Rx token available");
-                None
-            }
-        })
+        let is_empty = critical_section::with(|cs| self.data_queue_rx(cs).is_empty());
+
+        if !is_empty {
+            self.tx_token().map(|tx| (WifiRxToken { mode: self }, tx))
+        } else {
+            trace!("no Rx token available");
+            None
+        }
     }
 
     pub fn mac_address(self) -> [u8; 6] {

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -967,7 +967,6 @@ pub fn new_with_config<'d>(
         _ => {}
     }
 
-    // TODO: we'll need two devices for AP-STA mode
     let mode = WifiMode::try_from(&config)?;
 
     Ok((
@@ -997,10 +996,20 @@ pub fn new_with_mode<'d>(
     )
 }
 
-/// Creates a new [WifiDevice] and [WifiController] in AP-STA mode.
+/// Creates a new [WifiDevice] and [WifiController] in AP-STA mode, with a default configuration.
 ///
 /// Returns a tuple of `(AP device, STA device, controller)`.
 pub fn new_ap_sta<'d>(
+    inited: &EspWifiInitialization,
+    device: impl Peripheral<P = crate::hal::radio::Wifi> + 'd,
+) -> Result<(WifiDevice<'d>, WifiDevice<'d>, WifiController<'d>), WifiError> {
+    new_ap_sta_with_config(inited, device, Default::default(), Default::default())
+}
+
+/// Creates a new Wifi device and controller in AP-STA mode.
+///
+/// Returns a tuple of `(AP device, STA device, controller)`.
+pub fn new_ap_sta_with_config<'d>(
     inited: &EspWifiInitialization,
     device: impl Peripheral<P = crate::hal::radio::Wifi> + 'd,
     sta_config: embedded_svc::wifi::ClientConfiguration,

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1185,13 +1185,11 @@ impl<'d> WifiController<'d> {
         Ok(())
     }
 
-    #[allow(unused)]
-    fn is_sta_enabled(&self) -> Result<bool, WifiError> {
+    pub fn is_sta_enabled(&self) -> Result<bool, WifiError> {
         WifiMode::try_from(&self.config).map(|m| m.is_sta())
     }
 
-    #[allow(unused)]
-    fn is_ap_enabled(&self) -> Result<bool, WifiError> {
+    pub fn is_ap_enabled(&self) -> Result<bool, WifiError> {
         WifiMode::try_from(&self.config).map(|m| m.is_ap())
     }
 

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -895,11 +895,11 @@ pub unsafe extern "C" fn event_post(
     #[cfg(feature = "embassy-net")]
     match event {
         WifiEvent::StaConnected | WifiEvent::StaDisconnected => {
-            crate::wifi::embassy::LINK_STATE.wake();
+            crate::wifi::embassy::STA_LINK_STATE_WAKER.wake();
         }
 
         WifiEvent::ApStart | WifiEvent::ApStop => {
-            crate::wifi::embassy::LINK_STATE.wake();
+            crate::wifi::embassy::AP_LINK_STATE_WAKER.wake();
         }
 
         _ => {}

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -893,14 +893,16 @@ pub unsafe extern "C" fn event_post(
     event.waker().wake();
 
     #[cfg(feature = "embassy-net")]
-    if matches!(
-        event,
-        WifiEvent::StaConnected
-            | WifiEvent::StaDisconnected
-            | WifiEvent::ApStart
-            | WifiEvent::ApStop
-    ) {
-        crate::wifi::embassy::LINK_STATE.wake();
+    match event {
+        WifiEvent::StaConnected | WifiEvent::StaDisconnected => {
+            crate::wifi::embassy::LINK_STATE.wake();
+        }
+
+        WifiEvent::ApStart | WifiEvent::ApStop => {
+            crate::wifi::embassy::LINK_STATE.wake();
+        }
+
+        _ => {}
     }
 
     memory_fence();

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -71,10 +71,9 @@ pub struct ApStaInterface<'a, 'd> {
     pub sta_socket_set: SocketSet<'a>,
 }
 
-pub fn create_ap_sta_network_interface<'a, 'd, MODE: WifiDeviceMode>(
+pub fn create_ap_sta_network_interface<'a, 'd>(
     inited: &EspWifiInitialization,
     device: impl crate::hal::peripheral::Peripheral<P = crate::hal::peripherals::WIFI> + 'd,
-    _mode: MODE,
     ap_storage: &'a mut [SocketStorage<'a>],
     sta_storage: &'a mut [SocketStorage<'a>],
 ) -> Result<ApStaInterface<'a, 'd>, WifiError> {

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -7,44 +7,89 @@ use smoltcp::{
     wire::{EthernetAddress, HardwareAddress},
 };
 
-use crate::{current_millis, wifi::get_sta_mac};
-use crate::{wifi::get_ap_mac, EspWifiInitialization};
+use crate::current_millis;
+use crate::EspWifiInitialization;
 
-use super::{WifiController, WifiDevice, WifiError, WifiMode};
+use super::{WifiApDevice, WifiController, WifiDevice, WifiDeviceMode, WifiError, WifiStaDevice};
 
-/// Convenient way to create an `smoltcp` ethernet interface
-/// You can use the provided macros to create and pass a suitable backing storage.
-pub fn create_network_interface<'a, 'd>(
-    inited: &EspWifiInitialization,
-    device: impl crate::hal::peripheral::Peripheral<P = crate::hal::peripherals::WIFI> + 'd,
-    mode: WifiMode,
+fn setup_iface<'a, MODE: WifiDeviceMode>(
+    device: &mut WifiDevice<'_, MODE>,
+    mode: MODE,
     storage: &'a mut [SocketStorage<'a>],
-) -> Result<(Interface, WifiDevice<'d>, WifiController<'d>, SocketSet<'a>), WifiError> {
-    let socket_set_entries = storage;
-
-    let mut mac = [0u8; 6];
-    match mode.is_ap() {
-        true => get_ap_mac(&mut mac),
-        false => get_sta_mac(&mut mac),
-    }
+) -> (Interface, SocketSet<'a>) {
+    let mac = mode.mac_address();
     let hw_address = HardwareAddress::Ethernet(EthernetAddress::from_bytes(&mac));
-
-    let (mut device, controller) = crate::wifi::new_with_mode(inited, device, mode)?;
 
     let config = Config::new(hw_address);
     let iface = Interface::new(
         config,
-        &mut device,
+        device,
         Instant::from_millis(current_millis() as i64),
     );
 
-    let mut socket_set = SocketSet::new(socket_set_entries);
+    let mut socket_set = SocketSet::new(storage);
 
-    if !mode.is_ap() {
+    if mode.mode().is_sta() {
         // only add DHCP client in STA mode
         let dhcp_socket = Dhcpv4Socket::new();
         socket_set.add(dhcp_socket);
     }
 
+    (iface, socket_set)
+}
+
+/// Convenient way to create an `smoltcp` ethernet interface
+/// You can use the provided macros to create and pass a suitable backing storage.
+pub fn create_network_interface<'a, 'd, MODE: WifiDeviceMode>(
+    inited: &EspWifiInitialization,
+    device: impl crate::hal::peripheral::Peripheral<P = crate::hal::peripherals::WIFI> + 'd,
+    mode: MODE,
+    storage: &'a mut [SocketStorage<'a>],
+) -> Result<
+    (
+        Interface,
+        WifiDevice<'d, MODE>,
+        WifiController<'d>,
+        SocketSet<'a>,
+    ),
+    WifiError,
+> {
+    let (mut device, controller) = crate::wifi::new_with_mode(inited, device, mode)?;
+
+    let (iface, socket_set) = setup_iface(&mut device, mode, storage);
+
     Ok((iface, device, controller, socket_set))
+}
+
+pub struct ApStaInterface<'a, 'd> {
+    pub ap_interface: Interface,
+    pub sta_interface: Interface,
+    pub ap_device: WifiDevice<'d, WifiApDevice>,
+    pub sta_device: WifiDevice<'d, WifiStaDevice>,
+    pub controller: WifiController<'d>,
+    pub ap_socket_set: SocketSet<'a>,
+    pub sta_socket_set: SocketSet<'a>,
+}
+
+pub fn create_ap_sta_network_interface<'a, 'd, MODE: WifiDeviceMode>(
+    inited: &EspWifiInitialization,
+    device: impl crate::hal::peripheral::Peripheral<P = crate::hal::peripherals::WIFI> + 'd,
+    _mode: MODE,
+    ap_storage: &'a mut [SocketStorage<'a>],
+    sta_storage: &'a mut [SocketStorage<'a>],
+) -> Result<ApStaInterface<'a, 'd>, WifiError> {
+    let (mut ap_device, mut sta_device, controller) = crate::wifi::new_ap_sta(inited, device)?;
+
+    let (ap_interface, ap_socket_set) = setup_iface(&mut ap_device, WifiApDevice, ap_storage);
+    let (sta_interface, sta_socket_set) = setup_iface(&mut sta_device, WifiStaDevice, sta_storage);
+
+    Ok(ApStaInterface {
+        ap_interface,
+        sta_interface,
+        ap_device,
+        sta_device,
+        controller,
+        ap_socket_set,
+        sta_socket_set,
+    })
 }

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -12,7 +12,7 @@ use smoltcp::time::Instant;
 use smoltcp::wire::{DnsQueryType, IpAddress, IpCidr, IpEndpoint, Ipv4Address};
 
 use crate::current_millis;
-use crate::wifi::{get_ap_mac, get_sta_mac, WifiDevice, WifiMode};
+use crate::wifi::{get_ap_mac, get_sta_mac, WifiDevice, WifiDeviceMode};
 
 use core::borrow::BorrowMut;
 
@@ -78,9 +78,8 @@ impl<'a> WifiStack<'a> {
     ) -> Result<(), WifiStackError> {
         let mut mac = [0u8; 6];
         match self.device.borrow().get_wifi_mode() {
-            Ok(WifiMode::Sta) => get_sta_mac(&mut mac),
-            Ok(WifiMode::Ap) => get_ap_mac(&mut mac),
-            _ => (),
+            WifiDeviceMode::Sta => get_sta_mac(&mut mac),
+            WifiDeviceMode::Ap => get_ap_mac(&mut mac),
         }
         let hw_address = smoltcp::wire::HardwareAddress::Ethernet(
             smoltcp::wire::EthernetAddress::from_bytes(&mac),

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -12,15 +12,15 @@ use smoltcp::time::Instant;
 use smoltcp::wire::{DnsQueryType, IpAddress, IpCidr, IpEndpoint, Ipv4Address};
 
 use crate::current_millis;
-use crate::wifi::{get_ap_mac, get_sta_mac, WifiDevice, WifiDeviceMode};
+use crate::wifi::{WifiDevice, WifiDeviceMode};
 
 use core::borrow::BorrowMut;
 
 /// Non-async TCP/IP network stack
 ///
 /// Mostly a convenience wrapper for `smoltcp`
-pub struct WifiStack<'a> {
-    device: RefCell<WifiDevice<'static>>, // TODO allow non static lifetime
+pub struct WifiStack<'a, MODE: WifiDeviceMode> {
+    device: RefCell<WifiDevice<'static, MODE>>, // TODO allow non static lifetime
     network_interface: RefCell<Interface>,
     sockets: RefCell<SocketSet<'a>>,
     current_millis_fn: fn() -> u64,
@@ -31,13 +31,13 @@ pub struct WifiStack<'a> {
     dns_socket_handle: RefCell<Option<SocketHandle>>,
 }
 
-impl<'a> WifiStack<'a> {
+impl<'a, MODE: WifiDeviceMode> WifiStack<'a, MODE> {
     pub fn new(
         network_interface: Interface,
-        device: WifiDevice<'static>, // TODO relax this lifetime requirement
+        device: WifiDevice<'static, MODE>, // TODO relax this lifetime requirement
         mut sockets: SocketSet<'a>,
         current_millis_fn: fn() -> u64,
-    ) -> WifiStack<'a> {
+    ) -> WifiStack<'a, MODE> {
         let mut dhcp_socket_handle: Option<SocketHandle> = None;
         let mut dns_socket_handle: Option<SocketHandle> = None;
 
@@ -76,11 +76,7 @@ impl<'a> WifiStack<'a> {
         &self,
         conf: &ipv4::Configuration,
     ) -> Result<(), WifiStackError> {
-        let mut mac = [0u8; 6];
-        match self.device.borrow().get_wifi_mode() {
-            WifiDeviceMode::Sta => get_sta_mac(&mut mac),
-            WifiDeviceMode::Ap => get_ap_mac(&mut mac),
-        }
+        let mac = self.device.borrow().mac_address();
         let hw_address = smoltcp::wire::HardwareAddress::Ethernet(
             smoltcp::wire::EthernetAddress::from_bytes(&mac),
         );
@@ -239,7 +235,7 @@ impl<'a> WifiStack<'a> {
         &'s self,
         rx_buffer: &'a mut [u8],
         tx_buffer: &'a mut [u8],
-    ) -> Socket<'s, 'a>
+    ) -> Socket<'s, 'a, MODE>
     where
         'a: 's,
     {
@@ -264,7 +260,7 @@ impl<'a> WifiStack<'a> {
         rx_buffer: &'a mut [u8],
         tx_meta: &'a mut [smoltcp::socket::udp::PacketMetadata],
         tx_buffer: &'a mut [u8],
-    ) -> UdpSocket<'s, 'a>
+    ) -> UdpSocket<'s, 'a, MODE>
     where
         'a: 's,
     {
@@ -411,7 +407,7 @@ impl<'a> WifiStack<'a> {
     }
 
     #[allow(unused)]
-    fn with<R>(&self, f: impl FnOnce(&Interface, &WifiDevice, &SocketSet<'a>) -> R) -> R {
+    fn with<R>(&self, f: impl FnOnce(&Interface, &WifiDevice<MODE>, &SocketSet<'a>) -> R) -> R {
         f(
             &self.network_interface.borrow(),
             &self.device.borrow(),
@@ -421,7 +417,7 @@ impl<'a> WifiStack<'a> {
 
     fn with_mut<R>(
         &self,
-        f: impl FnOnce(&mut Interface, &mut WifiDevice, &mut SocketSet<'a>) -> R,
+        f: impl FnOnce(&mut Interface, &mut WifiDevice<MODE>, &mut SocketSet<'a>) -> R,
     ) -> R {
         f(
             &mut self.network_interface.borrow_mut(),
@@ -455,7 +451,7 @@ pub fn timestamp() -> Instant {
     Instant::from_millis(current_millis() as i64)
 }
 
-impl<'a> ipv4::Interface for WifiStack<'a> {
+impl<MODE: WifiDeviceMode> ipv4::Interface for WifiStack<'_, MODE> {
     type Error = WifiStackError;
 
     fn get_iface_configuration(&self) -> Result<ipv4::Configuration, Self::Error> {
@@ -476,12 +472,12 @@ impl<'a> ipv4::Interface for WifiStack<'a> {
 }
 
 /// A TCP socket
-pub struct Socket<'s, 'n: 's> {
+pub struct Socket<'s, 'n: 's, MODE: WifiDeviceMode> {
     socket_handle: SocketHandle,
-    network: &'s WifiStack<'n>,
+    network: &'s WifiStack<'n, MODE>,
 }
 
-impl<'s, 'n: 's> Socket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> Socket<'s, 'n, MODE> {
     /// Connect the socket
     pub fn open<'i>(&'i mut self, addr: IpAddress, port: u16) -> Result<(), IoError>
     where
@@ -611,7 +607,7 @@ impl<'s, 'n: 's> Socket<'s, 'n> {
     }
 }
 
-impl<'s, 'n: 's> Drop for Socket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> Drop for Socket<'s, 'n, MODE> {
     fn drop(&mut self) {
         self.network
             .with_mut(|_interface, _device, sockets| sockets.remove(self.socket_handle));
@@ -639,11 +635,11 @@ impl embedded_io::Error for IoError {
     }
 }
 
-impl<'s, 'n: 's> ErrorType for Socket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> ErrorType for Socket<'s, 'n, MODE> {
     type Error = IoError;
 }
 
-impl<'s, 'n: 's> Read for Socket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> Read for Socket<'s, 'n, MODE> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.network.with_mut(|interface, device, sockets| {
             use smoltcp::socket::tcp::RecvError;
@@ -663,7 +659,7 @@ impl<'s, 'n: 's> Read for Socket<'s, 'n> {
     }
 }
 
-impl<'s, 'n: 's> Write for Socket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> Write for Socket<'s, 'n, MODE> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         loop {
             let (may_send, is_open, can_send) =
@@ -728,12 +724,12 @@ impl<'s, 'n: 's> Write for Socket<'s, 'n> {
 }
 
 /// A UDP socket
-pub struct UdpSocket<'s, 'n: 's> {
+pub struct UdpSocket<'s, 'n: 's, MODE: WifiDeviceMode> {
     socket_handle: SocketHandle,
-    network: &'s WifiStack<'n>,
+    network: &'s WifiStack<'n, MODE>,
 }
 
-impl<'s, 'n: 's> UdpSocket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> UdpSocket<'s, 'n, MODE> {
     /// Binds the socket to the given port
     pub fn bind<'i>(&'i mut self, port: u16) -> Result<(), IoError>
     where
@@ -861,7 +857,7 @@ impl<'s, 'n: 's> UdpSocket<'s, 'n> {
     }
 }
 
-impl<'s, 'n: 's> Drop for UdpSocket<'s, 'n> {
+impl<'s, 'n: 's, MODE: WifiDeviceMode> Drop for UdpSocket<'s, 'n, MODE> {
     fn drop(&mut self) {
         self.network
             .with_mut(|_, _, sockets| sockets.borrow_mut().remove(self.socket_handle));


### PR DESCRIPTION
Built on top of #298

Open questions:
 - How do we want to return WifiDevice from `new_with_mode`? The AP-STA mode needs two devices (and consequently, two Stacks due to different link state, rx queues, etc.). We can return an enum (user needs to match), we can return a struct (ugh), or we can have different constructors (which removes the need for `embedded_svc::wifi::Configuration` which I consider a + because I don't like its None option and our need to handle it).
    > I'm happy with the current solution of 2 constructors. Please let me know if we should instead offer a different API.
    > That is, the constructors I propose:
    > - new_with_mode
    > - new_with_config
    > - new_ap_sta
    > - new_ap_sta_with_config
 - Are we fine with the bunch of runtime branching on the WifiDeviceMode
   - or should we prefer a bigger WifiDevice that stores references to the actual resources?
   - Option c is type-state in `WifiDevice`, which would allow keeping it zero-sized but with a bit of user-facing complexity bump.
   > I'm leaning towards type-state. Let me know if I shouldn't!
 - WifiController design isn't very well-suited for AP-STA mode: it is not currently possible e.g. to observe AP connection/disconnection events while also scanning. This isn't easy to solve as currently only one caller may wait for events (2 would race and would need 2 events to get unblocked for example).

TODO:
 - [ ] resolve open questions
 - [x] `set_configuration` shouldn't change the type of configuration
 - [x] examples
 - [x] add to examples.md
 - [ ] 🍝
 - [x] update readme
 - [ ] conversion between modes (maybe later?) (AP or STA -> AP-STA -> AP or STA)
   - Down-conversion (AP-STA -> AP or STA) could happen on Device::drop), up-conversion would need to return a new Device

Closes #190