### PR TITLE
Configure burst size on async Device, allow 0 as no maximum

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -986,7 +986,11 @@ impl Device for WifiDevice<'_> {
     fn capabilities(&self) -> smoltcp::phy::DeviceCapabilities {
         let mut caps = DeviceCapabilities::default();
         caps.max_transmission_unit = MTU;
-        caps.max_burst_size = Some(crate::CONFIG.max_burst_size);
+        caps.max_burst_size = if crate::CONFIG.max_burst_size == 0 {
+            None
+        } else {
+            Some(crate::CONFIG.max_burst_size)
+        };
         caps
     }
 }
@@ -1350,7 +1354,11 @@ pub(crate) mod embassy {
         fn capabilities(&self) -> Capabilities {
             let mut caps = Capabilities::default();
             caps.max_transmission_unit = MTU;
-            caps.max_burst_size = Some(crate::CONFIG.max_burst_size);
+            caps.max_burst_size = if crate::CONFIG.max_burst_size == 0 {
+                None
+            } else {
+                Some(crate::CONFIG.max_burst_size)
+            };
             caps
         }
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1350,7 +1350,7 @@ pub(crate) mod embassy {
         fn capabilities(&self) -> Capabilities {
             let mut caps = Capabilities::default();
             caps.max_transmission_unit = MTU;
-            caps.max_burst_size = Some(1);
+            caps.max_burst_size = Some(crate::CONFIG.max_burst_size);
             caps
         }
 


### PR DESCRIPTION
I wonder if this affect my case in #215

Oh yes, yes it does: `Test complete. Average speed: 129.1kB/s` 🎉