### PR TITLE
Fix early timeout when counter overflows

### DIFF
--- a/esp-wifi/src/timer/mod.rs
+++ b/esp-wifi/src/timer/mod.rs
@@ -40,3 +40,9 @@ pub fn ticks_to_micros(ticks: u64) -> u64 {
 pub fn ticks_to_millis(ticks: u64) -> u64 {
     ticks / (TICKS_PER_SECOND / 1_000)
 }
+
+/// Do not call this in a critical section!
+pub fn elapsed_time_since(start: u64) -> u64 {
+    let now = get_systimer_count();
+    time_diff(start, now)
+}

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -97,3 +97,9 @@ pub fn yield_task() {
 pub fn get_systimer_count() -> u64 {
     SystemTimer::now()
 }
+
+// TODO: use an Instance type instead...
+pub fn time_diff(start: u64, end: u64) -> u64 {
+    // 52-bit wrapping sub
+    end.wrapping_sub(start) & 0x000f_ffff_ffff_ffff
+}

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -119,3 +119,8 @@ pub fn yield_task() {
         core::arch::asm!("wsr.intset  {0}", in(reg) intr, options(nostack));
     }
 }
+
+// TODO: use an Instance type instead...
+pub fn time_diff(start: u64, end: u64) -> u64 {
+    end.wrapping_sub(start)
+}

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -748,11 +748,8 @@ pub unsafe extern "C" fn task_delete(_task_handle: *mut crate::binary::c_types::
  ****************************************************************************/
 pub unsafe extern "C" fn task_delay(tick: u32) {
     trace!("task_delay tick {}", tick);
-    let timeout = crate::timer::get_systimer_count() + tick as u64;
-    loop {
-        if crate::timer::get_systimer_count() >= timeout {
-            break;
-        }
+    let start_time = crate::timer::get_systimer_count();
+    while crate::timer::elapsed_time_since(start_time) < tick as u64 {
         yield_task();
     }
 }


### PR DESCRIPTION
I've split this out of #316 because it's an independent issue.

If in the previous code the `now() + block_time` overflowed, the code exited immediately because `now() > (now() + block_time)` was true. Instead, we calculate the number of elapsed ticks and compare that to the timeout. I get that this is basically once every 2 thousand years or so on Xtensa and 9 or so years on RISC-V, but the old code is still incorrect :)