### PR TITLE
Xtensa: Set up time slice before switching task, tweak tick rate

### DIFF
--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -19,17 +19,18 @@ use peripherals::INTPRI as SystemPeripheral;
 #[cfg(not(feature = "esp32c6"))]
 use peripherals::SYSTEM as SystemPeripheral;
 
+/// The timer responsible for time slicing.
 pub type TimeBase = Alarm<Target, 0>;
+static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
+const TIMESLICE_FREQUENCY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
+
+// Time keeping
 
 pub const TICKS_PER_SECOND: u64 = 16_000_000;
 
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
-
-static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
-
 pub fn setup_timer(systimer: TimeBase) {
     let alarm0 = systimer.into_periodic();
-    alarm0.set_period(TIMER_DELAY.into());
+    alarm0.set_period(TIMESLICE_FREQUENCY.into());
     alarm0.clear_interrupt();
     alarm0.interrupt_enable(true);
 
@@ -77,7 +78,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
         let mut alarm0 = ALARM0.borrow_ref_mut(cs);
         let alarm0 = unwrap!(alarm0.as_mut());
 
-        alarm0.set_period(TIMER_DELAY.into());
+        alarm0.set_period(TIMESLICE_FREQUENCY.into());
         alarm0.clear_interrupt();
     });
 

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -85,16 +85,14 @@ fn Timer0(_level: u32) {
 }
 
 fn do_task_switch(context: &mut TrapFrame) {
-    task_switch(context);
-
     critical_section::with(|cs| {
-        crate::memory_fence::memory_fence();
-
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();
         timer.start(TIMER_DELAY.into_duration());
     });
+
+    task_switch(context);
 }
 
 #[interrupt]

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -17,14 +17,15 @@ use crate::{
     preempt::preempt::task_switch,
 };
 
+/// The timer responsible for time slicing.
 pub type TimeBase = Timer<Timer0<TIMG1>>;
-
 static TIMER1: Mutex<RefCell<Option<TimeBase>>> = Mutex::new(RefCell::new(None));
+const TIMESLICE_FREQUENCY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
+
+// Time keeping
 
 static TIMER_OVERFLOWS: AtomicU32 = AtomicU32::new(0);
-
-const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tick_rate_hz);
-
+pub const CPU_CLOCK: u64 = 240_000_000; // ESP32, ESP32-S2 and ESP32-S3 all have 240MHz CPU clocks.
 pub const TICKS_PER_SECOND: u64 = 40_000_000;
 
 /// This function must not be called in a critical section. Doing so may return an incorrect value.
@@ -43,7 +44,7 @@ pub fn get_systimer_count() -> u64 {
     }
 
     // We have to precompute the divider to avoid overflow when multiplying.
-    const DIVIDER: u64 = 240_000_000 / TICKS_PER_SECOND;
+    const DIVIDER: u64 = CPU_CLOCK / TICKS_PER_SECOND;
     (((overflow as u64) << 32) + counter_after as u64) / DIVIDER
 }
 
@@ -54,11 +55,12 @@ pub fn setup_timer(mut timer1: TimeBase) {
     ));
 
     timer1.listen();
-    timer1.start(TIMER_DELAY.into_duration());
+    timer1.start(TIMESLICE_FREQUENCY.into_duration());
     critical_section::with(|cs| {
         TIMER1.borrow_ref_mut(cs).replace(timer1);
     });
 
+    // Set up the time keeping timer.
     xtensa_lx::timer::set_ccompare0(0xffffffff);
 }
 
@@ -89,7 +91,7 @@ fn do_task_switch(context: &mut TrapFrame) {
         let mut timer = TIMER1.borrow_ref_mut(cs);
         let timer = unwrap!(timer.as_mut());
         timer.clear_interrupt();
-        timer.start(TIMER_DELAY.into_duration());
+        timer.start(TIMESLICE_FREQUENCY.into_duration());
     });
 
     task_switch(context);

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -26,7 +26,8 @@ const TIMESLICE_FREQUENCY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CO
 
 static TIMER_OVERFLOWS: AtomicU32 = AtomicU32::new(0);
 pub const CPU_CLOCK: u64 = 240_000_000; // ESP32, ESP32-S2 and ESP32-S3 all have 240MHz CPU clocks.
-pub const TICKS_PER_SECOND: u64 = 40_000_000;
+pub const CLOCK_CYCLES_PER_TICK: u64 = 8;
+pub const TICKS_PER_SECOND: u64 = CPU_CLOCK / CLOCK_CYCLES_PER_TICK;
 
 /// This function must not be called in a critical section. Doing so may return an incorrect value.
 pub fn get_systimer_count() -> u64 {
@@ -43,9 +44,7 @@ pub fn get_systimer_count() -> u64 {
         overflow = TIMER_OVERFLOWS.load(Ordering::Relaxed);
     }
 
-    // We have to precompute the divider to avoid overflow when multiplying.
-    const DIVIDER: u64 = CPU_CLOCK / TICKS_PER_SECOND;
-    (((overflow as u64) << 32) + counter_after as u64) / DIVIDER
+    (((overflow as u64) << 32) + counter_after as u64) / CLOCK_CYCLES_PER_TICK
 }
 
 pub fn setup_timer(mut timer1: TimeBase) {


### PR DESCRIPTION
Similar to how it's done for RISC-V, set up the time-slice timer before switching tasks. This ensures that after a `yield_task`, the next task has the full time-slice to run.

I've changed the Xtensa tick rate to 30MHz. It doesn't affect much, and it's easier to calculate. We could probably use the original 240MHz but the wifi stack works with 32-bit timestamps and the 17 second range could be a bit too tight.