### PR TITLE
Make sure the scheduling won't start before everything is setup

### DIFF
--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -28,6 +28,11 @@ const TIMER_DELAY: fugit::HertzU32 = fugit::HertzU32::from_raw(crate::CONFIG.tic
 static ALARM0: Mutex<RefCell<Option<Alarm<Periodic, 0>>>> = Mutex::new(RefCell::new(None));
 
 pub fn setup_timer(systimer: TimeBase) {
+    // make sure the scheduling won't start before everything is setup
+    unsafe {
+        riscv::interrupt::disable();
+    }
+
     let alarm0 = systimer.into_periodic();
     alarm0.set_period(TIMER_DELAY.into());
     alarm0.clear_interrupt();


### PR DESCRIPTION
This fixes some obscure timing related problem that was first reliably discovered in https://github.com/esp-rs/esp-wifi/pull/300 but I think I also have seen it on ESP32-C3's static-ip example (but there it magically disappeared)

This PR disables interrupts globally until all the interrupts are configured

I also found a way to reproduce the problem on current main (at the time of writing) on ESP32-C6:
- in tasks.rs comment `#[cfg(coex)]`
- in `preemt/mod.rs` make sure to allocate three stacks
- run BLE example (or probably any other) with both, wifi and ble, enabled: `cargo run --release --example ble --features=ble,wifi`

(This supersedes #322)
