### PR TITLE
Add support coex for ESP32C6

### DIFF
--- a/esp-wifi-sys/ld/esp32c6/rom_functions.x
+++ b/esp-wifi-sys/ld/esp32c6/rom_functions.x
@@ -1468,3 +1468,36 @@ phy_param_rom = 0x4087fce8;
 
 PROVIDE ( esp_rom_delay_us = ets_delay_us );
 PROVIDE ( esp_rom_crc32_le = crc32_le );
+
+/***************************************
+ Group rom_coexist
+ ***************************************/
+
+/* Functions */
+esp_coex_rom_version_get = 0x40000afc;
+coex_bt_release = 0x40000b00;
+coex_bt_request = 0x40000b04;
+coex_core_ble_conn_dyn_prio_get = 0x40000b08;
+coex_core_event_duration_get = 0x40000b0c;
+coex_core_pti_get = 0x40000b10;
+coex_core_release = 0x40000b14;
+coex_core_request = 0x40000b18;
+coex_core_status_get = 0x40000b1c;
+coex_core_timer_idx_get = 0x40000b20;
+coex_event_duration_get = 0x40000b24;
+coex_hw_timer_disable = 0x40000b28;
+coex_hw_timer_enable = 0x40000b2c;
+coex_hw_timer_set = 0x40000b30;
+coex_schm_interval_set = 0x40000b34;
+coex_schm_lock = 0x40000b38;
+coex_schm_unlock = 0x40000b3c;
+coex_status_get = 0x40000b40;
+coex_wifi_release = 0x40000b44;
+esp_coex_ble_conn_dynamic_prio_get = 0x40000b48;
+/* Data (.data, .bss, .rodata) */
+coex_env_ptr = 0x4087ffc4;
+coex_pti_tab_ptr = 0x4087ffc0;
+coex_schm_env_ptr = 0x4087ffbc;
+coexist_funcs = 0x4087ffb8;
+g_coa_funcs_p = 0x4087ffb4;
+g_coex_param_ptr = 0x4087ffb0;

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -17,10 +17,7 @@ fn main() -> Result<(), String> {
         "#
         );
     }
-    #[cfg(all(
-        feature = "coex",
-        any(feature = "esp32s2", feature = "esp32c2")
-    ))]
+    #[cfg(all(feature = "coex", any(feature = "esp32s2", feature = "esp32c2")))]
     {
         panic!(
             r#"

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), String> {
     }
     #[cfg(all(
         feature = "coex",
-        any(feature = "esp32s2", feature = "esp32c2", feature = "esp32c6")
+        any(feature = "esp32s2", feature = "esp32c2")
     ))]
     {
         panic!(

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -1055,10 +1055,13 @@ pub(crate) fn ble_init() {
         // init bb
         bt_bb_v2_init_cmplx(1);
 
-        // let rc = ble_osi_coex_funcs_register(&G_COEX_FUNCS as *const osi_coex_funcs_t);
-        // if res != 0 {
-        //     panic!("ble_osi_coex_funcs_register returned {}", res);
-        // }
+        #[cfg(coex)]
+        {
+            let rc = ble_osi_coex_funcs_register(&G_COEX_FUNCS as *const osi_coex_funcs_t);
+            if rc != 0 {
+                panic!("ble_osi_coex_funcs_register returned {}", rc);
+            }
+        }
 
         let res = ble_controller_init(&cfg as *const esp_bt_controller_config_t);
 

--- a/esp-wifi/src/compat/timer_compat.rs
+++ b/esp-wifi/src/compat/timer_compat.rs
@@ -40,7 +40,9 @@ impl Timer {
         self.ets_timer as usize
     }
 }
-
+#[cfg(coex)]
+pub(crate) static mut TIMERS: heapless::Vec<Timer, 30> = heapless::Vec::new();
+#[cfg(not(coex))]
 pub(crate) static mut TIMERS: heapless::Vec<Timer, 20> = heapless::Vec::new();
 
 pub fn compat_timer_arm(ets_timer: *mut ets_timer, tmout: u32, repeat: bool) {

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -109,7 +109,7 @@ const DEFAULT_TICK_RATE_HZ: u32 = 100;
 struct Config {
     #[default(5)]
     rx_queue_size: usize,
-    #[default(3)]
+    #[default(10)]
     tx_queue_size: usize,
     #[default(10)]
     static_rx_buf_num: usize,

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -109,7 +109,7 @@ const DEFAULT_TICK_RATE_HZ: u32 = 100;
 struct Config {
     #[default(5)]
     rx_queue_size: usize,
-    #[default(10)]
+    #[default(3)]
     tx_queue_size: usize,
     #[default(10)]
     static_rx_buf_num: usize,

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -308,7 +308,7 @@ pub enum InternalWifiError {
     EspErrWifiTxDisallow = 0x3016,
 }
 
-#[cfg(all(coex, any(esp32, esp32c3, esp32s3)))]
+#[cfg(all(coex, any(esp32, esp32c3, esp32c6, esp32s3)))]
 static mut G_COEX_ADAPTER_FUNCS: coex_adapter_funcs_t = coex_adapter_funcs_t {
     _version: include::COEX_ADAPTER_VERSION as i32,
     _task_yield_from_isr: Some(task_yield_from_isr),


### PR DESCRIPTION
Hi @bugadani, @bjoernQ,

I created a PR to support Coex for ESP32C6. Those changes were discussed from https://github.com/esp-rs/esp-wifi/pull/300

+ Enabled `COEX `feature and created new `COEX `example for ESP32C6.
+ Added `big-heap` when run COEX mode.
+ Calling `G_COEX_FUNCS` in COEX mode
+ Increase `tx_queue_size `to be greater than rx_queue_size