### PR TITLE
Pin static_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ embassy-futures = { version = "0.1.0" }
 toml-cfg = "0.1.3"
 libm = "0.2.7"
 cfg-if = "1.0.0"
-static_cell = { version = "1", features = ["nightly"] }
+static_cell = { version = "=1.2", features = ["nightly"] }
 
 embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }


### PR DESCRIPTION
`static_cell` 1.3 was released today dropping `atomic-polyfill` in favour of `portable-atomic`. Unfortunately, `portable-atomic` isn't compatible with something in RISC-V atomic emulation. This PR pins the old version as a band-aid so CI can stay blissfully ignorant.