### PR TITLE
Avoid running CI twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Pushing to a PR starts two runs:

![image](https://github.com/esp-rs/esp-wifi/assets/977627/0d25eb6c-2fd1-4cb8-a29b-989d010effa6)

this change only starts CI for pushes to the main branch, or PRs opened against the main branch instead.