### PR TITLE
Simplify multitasking

### DIFF
--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -9,7 +9,7 @@ use crate::{
         include::OSI_FUNCS_TIME_BLOCKING,
     },
     memory_fence::memory_fence,
-    preempt::preempt::current_task,
+    preempt::current_task,
     timer::yield_task,
 };
 

--- a/esp-wifi/src/preempt/mod.rs
+++ b/esp-wifi/src/preempt/mod.rs
@@ -1,12 +1,3 @@
-use atomic_polyfill::AtomicBool;
-use core::sync::atomic::Ordering;
-
-pub static mut FIRST_SWITCH: AtomicBool = AtomicBool::new(true);
-
-static mut TASK_TOP: usize = 0;
-
-static mut CTX_NOW: usize = 0;
-
 macro_rules! sum {
     ($h:expr) => ($h);
     ($h:expr, $($t:expr),*) =>
@@ -22,6 +13,28 @@ macro_rules! task_stack {
 
         static mut TASK_STACK: [u8; TOTAL_STACK_SIZE] = [0u8; TOTAL_STACK_SIZE];
     };
+}
+
+static mut TASK_TOP: usize = 1;
+static mut CTX_NOW: usize = 0;
+
+fn allocate_task() -> usize {
+    unsafe {
+        let i = TASK_TOP - 1;
+        CTX_NOW = TASK_TOP;
+        TASK_TOP += 1;
+        i
+    }
+}
+
+fn next_task() {
+    unsafe {
+        CTX_NOW = (CTX_NOW + 1) % TASK_TOP;
+    }
+}
+
+pub fn current_task() -> usize {
+    unsafe { CTX_NOW }
 }
 
 #[cfg(coex)]

--- a/esp-wifi/src/timer/mod.rs
+++ b/esp-wifi/src/timer/mod.rs
@@ -19,6 +19,8 @@ pub fn setup_timer_isr(timebase: TimeBase) {
     setup_timer(timebase);
 
     setup_multitasking();
+
+    yield_task();
 }
 
 #[allow(unused)]

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -1,5 +1,4 @@
 use core::cell::RefCell;
-use core::sync::atomic::Ordering;
 
 use critical_section::Mutex;
 
@@ -56,8 +55,6 @@ pub fn setup_multitasking() {
     unsafe {
         riscv::interrupt::enable();
     }
-
-    while unsafe { crate::preempt::FIRST_SWITCH.load(Ordering::Relaxed) } {}
 }
 
 #[interrupt]

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -73,8 +73,6 @@ pub fn setup_multitasking() {
                 | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask() | enabled,
         );
     }
-
-    while unsafe { crate::preempt::FIRST_SWITCH.load(Ordering::Relaxed) } {}
 }
 
 #[allow(non_snake_case)]

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -789,7 +789,7 @@ pub unsafe extern "C" fn task_ms_to_tick(ms: u32) -> i32 {
  *
  ****************************************************************************/
 pub unsafe extern "C" fn task_get_current_task() -> *mut crate::binary::c_types::c_void {
-    let res = crate::preempt::preempt::current_task() as *mut crate::binary::c_types::c_void;
+    let res = crate::preempt::current_task() as *mut crate::binary::c_types::c_void;
     trace!("task get current task - return {:?}", res);
 
     res


### PR DESCRIPTION
My hypothesis is that we can get rid of the `FIRST_SWITCH` flag, saving a few instructions on each task switch.

I hope this works on RISC-V but we can restore the flag on it if not.