### PR TITLE
Add features to disable various network protocols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: cd esp-wifi && cargo b${{ matrix.chip }} --features=async,wifi,esp-now,embassy-net,log,${{ matrix.chip }}-hal/embassy-time-timg0
       - name: build (common features + defmt)
         run: cd esp-wifi && cargo b${{ matrix.chip }} --no-default-features --features=async,wifi,esp-now,embassy-net,defmt,${{ matrix.chip }}-hal/embassy-time-timg0
+      - name: build (all possible network options)
+        run: cd esp-wifi && for combo in {ipv4,},{ipv6,},{tcp,},{udp,},{igmp,},{dhcpv4,} ; do cargo b${{ matrix.chip }} --release --no-default-features --features=wifi,wifi-logs,$combo ; done
       - name: build (access_point)
         run: cd esp-wifi && cargo b${{ matrix.chip }} --release --example=access_point --features=wifi
       - name: build (access_point_with_sta)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ esp32c6-hal = { version = "0.6.0",  default-features = false }
 esp32-hal   = { version = "0.16.0", default-features = false }
 esp32s3-hal = { version = "0.13.0", default-features = false }
 esp32s2-hal = { version = "0.13.0", default-features = false }
-smoltcp = { version = "0.10.0", default-features = false, features = ["proto-igmp", "proto-ipv4", "proto-dns", "socket-tcp", "socket-icmp", "socket-udp", "socket-dns", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
 atomic-polyfill = "1.0.2"
 atomic_enum = "0.2.0" # uses core atomic types which should be fine as long as only load and store is used on them

--- a/README.md
+++ b/README.md
@@ -74,24 +74,29 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG since it might re
 
 ## Features
 
-| Feature        | Meaning                                                                                             |
-| -------------- | --------------------------------------------------------------------------------------------------- |
-| wifi-logs      | logs the WiFi logs from the driver at log level info                                                |
-| dump-packets   | dumps packet info at log level info                                                                 |
-| utils          | Provide utilities for smoltcp initialization, this is a default feature                             |
-| embedded-svc   | Provides a (very limited) implementation of the `embedded-svc` WiFi trait, includes `utils` feature |
-| ble            | Enable BLE support                                                                                  |
-| wifi           | Enable WiFi support                                                                                 |
-| esp-now        | Enable esp-now support                                                                              |
-| coex           | Enable coex support                                                                                 |
-| mtu-XXX        | Set MTU to XXX, XXX can be 746, 1492, 1500, 1514. Defaults to 1492                                  |
-| big-heap       | Reserve more heap memory for the drivers                                                            |
-| ipv6           | IPv6 support                                                                                        |
-| phy-enable-usb | See _USB-SERIAL-JTAG_ below                                                                         |
-| ps-min-modem   | Enable minimum modem sleep. Only for STA mode                                                       |
-| ps-max-modem   | Enable maximum modem sleep. Only for STA mode                                                       |
-| log            | Route log output to the `log` crate                                                                 |
-| defmt          | Add `defmt::Format` implementation                                                                  |
+| Feature        | Meaning                                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------------------- |
+| wifi-logs      | logs the WiFi logs from the driver at log level info                                                 |
+| dump-packets   | dumps packet info at log level info                                                                  |
+| utils          | Provide utilities for smoltcp initialization; adds `smoltcp` dependency                              |
+| embedded-svc   | Provides a (very limited) implementation of the `embedded-svc` WiFi trait                            |        
+| ble            | Enable BLE support                                                                                   |
+| wifi           | Enable WiFi support                                                                                  |
+| esp-now        | Enable esp-now support                                                                               |
+| coex           | Enable coex support                                                                                  |
+| big-heap       | Reserve more heap memory for the drivers                                                             |
+| ipv4           | IPv4 support: includes `utils` feature                                                               |
+| ipv6           | IPv6 support: includes `utils` feature                                                               |
+| tcp            | TCP socket support: includes `ipv4` feature                                                          |
+| udp            | UDP socket support: includes `ipv4` feature                                                          |
+| igmp           | IGMP (multicast) support: includes `ipv4` feature                                                    |
+| dns            | DNS support: includes `udp` feature                                                                  |
+| dhcpv4         | DHCPv4 support, both creating sockets and autoconfiguring network settings: includes `utils` feature |
+| phy-enable-usb | See _USB-SERIAL-JTAG_ below                                                                          |
+| ps-min-modem   | Enable minimum modem sleep. Only for STA mode                                                        |
+| ps-max-modem   | Enable maximum modem sleep. Only for STA mode                                                        |
+| log            | Route log output to the `log` crate                                                                  |
+| defmt          | Add `defmt::Format` implementation                                                                   |
 
 When using the `dump-packets` feature you can use the extcap in `extras/esp-wifishark` to analyze the frames in Wireshark.
 For more information see [extras/esp-wifishark/README.md](extras/esp-wifishark/README.md)

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -51,7 +51,7 @@ smoltcp.workspace = true
 static_cell.workspace = true
 
 [features]
-default = [ "utils", "log" ]
+default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4" ]
 
 # chip features
 esp32c2 = [ "esp32c2-hal", "esp-wifi-sys/esp32c2", "esp-println/esp32c2", "esp-backtrace/esp32c2", "embassy-executor/arch-riscv32" ]
@@ -87,9 +87,10 @@ embassy-net = ["dep:embassy-net", "async"]
 coex = []
 wifi-logs = []
 dump-packets = []
-utils = [ "dep:smoltcp" ]
+smoltcp = [ "dep:smoltcp" ]
+utils = [ "smoltcp" ]
 enumset = []
-embedded-svc = [ "dep:enumset", "dep:embedded-svc", "utils" ]
+embedded-svc = [ "dep:enumset", "dep:embedded-svc" ]
 wifi = [ "embedded-svc" ]
 ble = [ "esp32-hal?/bluetooth" ]
 phy-enable-usb = []
@@ -97,7 +98,14 @@ ps-min-modem = []
 ps-max-modem = []
 esp-now = [ "wifi" ]
 big-heap = []
-ipv6 = ["smoltcp?/proto-ipv6"]
+ipv6 = ["wifi", "utils", "smoltcp?/proto-ipv6"]
+ipv4 = ["wifi", "utils", "smoltcp?/proto-ipv4"]
+tcp = ["ipv4", "smoltcp?/socket-tcp"]
+udp = ["ipv4", "smoltcp?/socket-udp"]
+icmp = ["ipv4", "smoltcp?/socket-icmp"]
+igmp = ["ipv4", "smoltcp?/proto-igmp"]
+dns = ["udp", "smoltcp?/proto-dns", "smoltcp?/socket-dns"]
+dhcpv4 = ["wifi", "utils", "smoltcp?/proto-dhcpv4", "smoltcp?/socket-dhcpv4"]
 defmt = [
   "dep:defmt",
   "smoltcp?/defmt",

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -72,7 +72,11 @@ pub(crate) mod memory_fence;
 use critical_section;
 use timer::{get_systimer_count, ticks_to_millis};
 
-#[cfg(all(feature = "embedded-svc", feature = "wifi"))]
+#[cfg(all(
+    feature = "embedded-svc",
+    feature = "wifi",
+    any(feature = "tcp", feature = "udp")
+))]
 pub mod wifi_interface;
 
 /// Return the current systimer time in milliseconds

--- a/esp-wifi/src/wifi/utils.rs
+++ b/esp-wifi/src/wifi/utils.rs
@@ -1,8 +1,9 @@
 //! Convenience utilities for non-async code
 
+#[cfg(feature = "dhcpv4")]
+use smoltcp::socket::dhcpv4::Socket as Dhcpv4Socket;
 use smoltcp::{
     iface::{Config, Interface, SocketSet, SocketStorage},
-    socket::dhcpv4::Socket as Dhcpv4Socket,
     time::Instant,
     wire::{EthernetAddress, HardwareAddress},
 };
@@ -27,8 +28,10 @@ fn setup_iface<'a, MODE: WifiDeviceMode>(
         Instant::from_millis(current_millis() as i64),
     );
 
+    #[allow(unused_mut)]
     let mut socket_set = SocketSet::new(storage);
 
+    #[cfg(feature = "dhcpv4")]
     if mode.mode().is_sta() {
         // only add DHCP client in STA mode
         let dhcp_socket = Dhcpv4Socket::new();


### PR DESCRIPTION
smoltcp has feature flags to allow enabling and disabling several protocols.  Expose those feature flags to users of esp-wifi as well, to let them trim down both esp-wifi and smoltcp.

Also added a loop to the CI config to build with all combinations of all these new feature flags, to ensure all the possible combinations continue to work.

Fixes #290 