### PR TITLE
Update dependencies, port to portable-atomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,22 @@ esp-println = { version = "0.7.0" }
 esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-handler", "print-uart"] }
 embedded-hal-async = { version = "1.0.0-rc.1" }
 embedded-io-async = { version = "0.6.0" }
+
+futures-util = { version = "0.3.28", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on futures-util's AtomicWaker even though we don't use it
+
+[patch.crates-io]
+esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git" }
+
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
+embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
+embassy-net-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
+
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "b57e2f9e70e82a13f31d5ea17e55232c11cc2b2d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ esp32s3-hal = { version = "0.13.0", default-features = false }
 esp32s2-hal = { version = "0.13.0", default-features = false }
 smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
-atomic-polyfill = "1.0.2"
-atomic_enum = "0.2.0" # uses core atomic types which should be fine as long as only load and store is used on them
-log = "0.4.18"
+portable-atomic = { version = "1.5", default-features = false }
+portable_atomic_enum = "0.2.0"
+log = "0.4.20"
 embedded-svc = { version = "0.26.1", default-features = false, features = [] }
 enumset = { version = "1", default-features = false }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 embedded-io = "0.6.1"
 fugit = "0.3.7"
-heapless = { version = "0.7.16", default-features = false }
-num-derive = { version = "0.3", features = ["full-syntax"] }
+heapless = { version = "0.8.0", default-features = false }
+num-derive = { version = "0.4" }
 num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { version = "0.4.0" }
@@ -41,14 +41,14 @@ embassy-futures = { version = "0.1.0" }
 toml-cfg = "0.1.3"
 libm = "0.2.7"
 cfg-if = "1.0.0"
-static_cell = { version = "=1.2", features = ["nightly"] }
+static_cell = { version = "2.0", features = ["nightly"] }
 
 embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }
-embassy-executor = { version = "=0.3.2", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] } # temporarily pin because we aren't ready for portable-atomic yet
+embassy-executor = { version = "0.3.3", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] }
 embassy-time = { version = "0.1.3", features = ["nightly"] }
 futures-util = { version = "0.3.28", default-features = false }
-esp-println = { version = "0.6.0" }
-esp-backtrace = { version = "0.8.0", features = ["panic-handler", "exception-handler", "print-uart"] }
+esp-println = { version = "0.7.0" }
+esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-handler", "print-uart"] }
 embedded-hal-async = { version = "1.0.0-rc.1" }
 embedded-io-async = { version = "0.6.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ enumset = { version = "1", default-features = false }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 embedded-io = "0.6.1"
 fugit = "0.3.7"
-heapless = { version = "0.8.0", default-features = false }
+heapless = { version = "0.7.16", default-features = false }
 num-derive = { version = "0.4" }
 num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
@@ -53,6 +53,7 @@ embedded-hal-async = { version = "1.0.0-rc.1" }
 embedded-io-async = { version = "0.6.0" }
 
 futures-util = { version = "0.3.28", default-features = false } # need this to activate portable-atomic on AtomicWaker even though we don't use it
+atomic-waker = { version = "1.1.2", default-features = false } # need this to activate portable-atomic on AtomicWaker used by embedded-svc even though we don't use it
 
 [patch.crates-io]
 esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
@@ -62,11 +63,3 @@ esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
 esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
 esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
 esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-embedded-svc = { git = "https://github.com/esp-rs/embedded-svc.git" }
-
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
-embassy-net-driver = { git = "https://github.com/embassy-rs/embassy.git", rev = "7e5deae" }
-
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "b57e2f9e70e82a13f31d5ea17e55232c11cc2b2d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,12 @@ embedded-io-async = { version = "0.6.0" }
 futures-util = { version = "0.3.28", default-features = false } # need this to activate portable-atomic on AtomicWaker even though we don't use it
 atomic-waker = { version = "1.1.2", default-features = false } # need this to activate portable-atomic on AtomicWaker used by embedded-svc even though we don't use it
 
+# portable-atomic compatible esp-hal revisions
 [patch.crates-io]
-esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }
+esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4"
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }
 embassy-executor = { version = "0.3.3", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] }
 embassy-time = { version = "0.1.3", features = ["nightly"] }
-futures-util = { version = "0.3.28", default-features = false }
 esp-println = { version = "0.7.0" }
 esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-handler", "print-uart"] }
 embedded-hal-async = { version = "1.0.0-rc.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ esp32s2-hal = { version = "0.13.0", default-features = false }
 smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
 portable-atomic = { version = "1.5", default-features = false }
-portable_atomic_enum = "0.2.0"
+portable_atomic_enum = "0.3.0"
 log = "0.4.20"
 embedded-svc = { version = "0.26.1", default-features = false, features = [] }
 enumset = { version = "1", default-features = false }
@@ -52,7 +52,7 @@ esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-han
 embedded-hal-async = { version = "1.0.0-rc.1" }
 embedded-io-async = { version = "0.6.0" }
 
-futures-util = { version = "0.3.28", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on futures-util's AtomicWaker even though we don't use it
+futures-util = { version = "0.3.28", default-features = false } # need this to activate portable-atomic on AtomicWaker even though we don't use it
 
 [patch.crates-io]
 esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "957b232" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ esp32s2-hal = { version = "0.13.0", default-features = false }
 smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
 portable-atomic = { version = "1.5", default-features = false }
-portable_atomic_enum = "0.3.0"
+portable_atomic_enum = { version = "0.3.0", features = ["portable-atomic"] }
 log = "0.4.20"
 embedded-svc = { version = "0.26.1", default-features = false, features = [] }
-enumset = { version = "1", default-features = false }
+enumset = { version = "1.1.3", default-features = false }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 embedded-io = "0.6.1"
 fugit = "0.3.7"
@@ -45,22 +45,22 @@ static_cell = { version = "2.0", features = ["nightly"] }
 
 embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }
-embassy-executor = { version = "0.3.3", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] }
+embassy-executor = { version = "0.3.3", package = "embassy-executor", features = ["nightly", "integrated-timers"] }
 embassy-time = { version = "0.1.3", features = ["nightly"] }
 esp-println = { version = "0.7.0" }
 esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-handler", "print-uart"] }
 embedded-hal-async = { version = "1.0.0-rc.1" }
 embedded-io-async = { version = "0.6.0" }
 
-futures-util = { version = "0.3.28", default-features = false } # need this to activate portable-atomic on AtomicWaker even though we don't use it
-atomic-waker = { version = "1.1.2", default-features = false } # need this to activate portable-atomic on AtomicWaker used by embedded-svc even though we don't use it
+futures-util = { version = "0.3.28", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on AtomicWaker even though we don't use it
+atomic-waker = { version = "1.1.2", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on AtomicWaker used by embedded-svc even though we don't use it
 
 # portable-atomic compatible esp-hal revisions
 [patch.crates-io]
-esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "7084a380" }
+esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }

--- a/esp-wifi/.cargo/config.toml
+++ b/esp-wifi/.cargo/config.toml
@@ -5,17 +5,17 @@
 #   - `embassy-executor-thread` on Xtensa chips to take advantage of the Xtensa specific executor we have in esp-hal
 [alias]
 esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
-esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
+esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread,portable-atomic/critical-section"
 esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
-esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0"
-esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0"
+esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
+esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
 esp32c6 = "run --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
 
 besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
-besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
+besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread,portable-atomic/critical-section"
 besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
-besp32c2 = "build --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0"
-besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0"
+besp32c2 = "build --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
+besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
 besp32c6 = "build --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
 
 [target.riscv32imc-unknown-none-elf]
@@ -23,24 +23,7 @@ runner = "espflash flash --monitor"
 rustflags = [
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
-
     "-C", "force-frame-pointers",
-
-    # Enable the atomic codegen option for RISCV
-    "-C", "target-feature=+a",
-
-    # tell the core library have atomics even though it's not specified in the target definition
-    "--cfg", "target_has_atomic_load_store",
-    "--cfg", 'target_has_atomic_load_store="8"',
-    "--cfg", 'target_has_atomic_load_store="16"',
-    "--cfg", 'target_has_atomic_load_store="32"',
-    "--cfg", 'target_has_atomic_load_store="ptr"',
-    # enable cas
-    "--cfg", "target_has_atomic",
-    "--cfg", 'target_has_atomic="8"',
-    "--cfg", 'target_has_atomic="16"',
-    "--cfg", 'target_has_atomic="32"',
-    "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [target.riscv32imac-unknown-none-elf]
@@ -70,23 +53,6 @@ runner = "espflash flash --monitor"
 rustflags = [
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
-
-    # Enable the atomic codegen option for Xtensa
-    "-C", "target-feature=+s32c1i",
-
-    # tell the core library have atomics even though it's not specified in the target definition
-    "--cfg", "target_has_atomic_load_store",
-    "--cfg", 'target_has_atomic_load_store="8"',
-    "--cfg", 'target_has_atomic_load_store="16"',
-    "--cfg", 'target_has_atomic_load_store="32"',
-    "--cfg", 'target_has_atomic_load_store="ptr"',
-    # Tell the `core` library that we have atomics, even though it's not
-    # specified in the target definition
-    "--cfg", 'target_has_atomic',
-    "--cfg", 'target_has_atomic="8"',
-    "--cfg", 'target_has_atomic="16"',
-    "--cfg", 'target_has_atomic="32"',
-    "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [unstable]

--- a/esp-wifi/.cargo/config.toml
+++ b/esp-wifi/.cargo/config.toml
@@ -7,16 +7,16 @@
 esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
 esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
 esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
-esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0"
-esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0"
-esp32c6 = "run --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
+esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,esp32c2-hal/embassy-executor-thread"
+esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,esp32c3-hal/embassy-executor-thread"
+esp32c6 = "run --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0,esp32c6-hal/embassy-executor-thread"
 
 besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
 besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
 besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
-besp32c2 = "build --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
-besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
-besp32c6 = "build --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
+besp32c2 = "build --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,esp32c2-hal/embassy-executor-thread"
+besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,esp32c3-hal/embassy-executor-thread"
+besp32c6 = "build --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0,esp32c6-hal/embassy-executor-thread"
 
 [target.riscv32imc-unknown-none-elf]
 runner = "espflash flash --monitor"
@@ -54,24 +54,6 @@ rustflags = [
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
     "-C", "force-frame-pointers",
-
-    # TODO: these should be removed but heapless 0.7 would fail to compile without it
-    # Enable the atomic codegen option for Xtensa.
-    "-C", "target-feature=+s32c1i",
-
-    # tell the core library have atomics even though it's not specified in the target definition
-    "--cfg", "target_has_atomic_load_store",
-    "--cfg", 'target_has_atomic_load_store="8"',
-    "--cfg", 'target_has_atomic_load_store="16"',
-    "--cfg", 'target_has_atomic_load_store="32"',
-    "--cfg", 'target_has_atomic_load_store="ptr"',
-    # Tell the `core` library that we have atomics, even though it's not
-    # specified in the target definition
-    "--cfg", 'target_has_atomic',
-    "--cfg", 'target_has_atomic="8"',
-    "--cfg", 'target_has_atomic="16"',
-    "--cfg", 'target_has_atomic="32"',
-    "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [unstable]

--- a/esp-wifi/.cargo/config.toml
+++ b/esp-wifi/.cargo/config.toml
@@ -7,8 +7,8 @@
 esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
 esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
 esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
-esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
-esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
+esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0"
+esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0"
 esp32c6 = "run --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
 
 besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"

--- a/esp-wifi/.cargo/config.toml
+++ b/esp-wifi/.cargo/config.toml
@@ -5,14 +5,14 @@
 #   - `embassy-executor-thread` on Xtensa chips to take advantage of the Xtensa specific executor we have in esp-hal
 [alias]
 esp32 =   "run --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
-esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread,portable-atomic/critical-section"
+esp32s2 = "run --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
 esp32s3 = "run --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
 esp32c2 = "run --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
 esp32c3 = "run --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
 esp32c6 = "run --features esp32c6 --target riscv32imac-unknown-none-elf --features esp32c6-hal/default,esp32c6-hal/embassy-time-timg0"
 
 besp32 =   "build --features   esp32 --target xtensa-esp32-none-elf        --features esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread"
-besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread,portable-atomic/critical-section"
+besp32s2 = "build --features esp32s2 --target xtensa-esp32s2-none-elf      --features esp32s2-hal/default,esp32s2-hal/embassy-time-timg0,esp32s2-hal/embassy-executor-thread"
 besp32s3 = "build --features esp32s3 --target xtensa-esp32s3-none-elf      --features esp32s3-hal/default,esp32s3-hal/embassy-time-timg0,esp32s3-hal/embassy-executor-thread"
 besp32c2 = "build --features esp32c2 --target riscv32imc-unknown-none-elf  --features esp32c2-hal/default,esp32c2-hal/embassy-time-timg0,portable-atomic/critical-section"
 besp32c3 = "build --features esp32c3 --target riscv32imc-unknown-none-elf  --features esp32c3-hal/default,esp32c3-hal/embassy-time-timg0,portable-atomic/critical-section"
@@ -53,6 +53,25 @@ runner = "espflash flash --monitor"
 rustflags = [
     "-C", "link-arg=-Tlinkall.x",
     "-C", "link-arg=-Trom_functions.x",
+    "-C", "force-frame-pointers",
+
+    # TODO: these should be removed but heapless 0.7 would fail to compile without it
+    # Enable the atomic codegen option for Xtensa.
+    "-C", "target-feature=+s32c1i",
+
+    # tell the core library have atomics even though it's not specified in the target definition
+    "--cfg", "target_has_atomic_load_store",
+    "--cfg", 'target_has_atomic_load_store="8"',
+    "--cfg", 'target_has_atomic_load_store="16"',
+    "--cfg", 'target_has_atomic_load_store="32"',
+    "--cfg", 'target_has_atomic_load_store="ptr"',
+    # Tell the `core` library that we have atomics, even though it's not
+    # specified in the target definition
+    "--cfg", 'target_has_atomic',
+    "--cfg", 'target_has_atomic="8"',
+    "--cfg", 'target_has_atomic="16"',
+    "--cfg", 'target_has_atomic="32"',
+    "--cfg", 'target_has_atomic="ptr"',
 ]
 
 [unstable]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -38,8 +38,8 @@ linked_list_allocator = { workspace = true }
 embedded-io.workspace = true
 embedded-io-async = { workspace = true, optional = true }
 fugit.workspace = true
-heapless = { workspace = true, default-features = false }
-num-derive = { workspace = true, features = ["full-syntax"] }
+heapless = { workspace = true, default-features = false, features = ["portable-atomic"] }
+num-derive = { workspace = true }
 num-traits = { workspace = true, default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
 embassy-sync = { workspace = true, optional = true }
@@ -48,8 +48,11 @@ embassy-net = { workspace = true, optional = true }
 toml-cfg.workspace = true
 libm.workspace = true
 cfg-if.workspace = true
-atomic-polyfill.workspace = true
-atomic_enum.workspace = true
+portable-atomic.workspace = true
+portable_atomic_enum.workspace = true
+
+# We don't use it directly but we need to enable portable-atomic on it
+futures-util.workspace = true
 
 [build-dependencies]
 toml-cfg.workspace = true
@@ -64,6 +67,7 @@ bleps = { workspace = true, features = ["async"] }
 embedded-hal-async.workspace = true
 log.workspace = true
 static_cell.workspace = true
+portable-atomic = { workspace = true, features = ["critical-section"] }
 
 [features]
 default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4" ]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -62,7 +62,6 @@ esp-println = { workspace = true, features = ["log"] }
 esp-backtrace.workspace = true
 embassy-executor.workspace = true
 embassy-time.workspace = true
-futures-util.workspace = true
 bleps = { workspace = true, features = ["async"] }
 embedded-hal-async.workspace = true
 log.workspace = true

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -51,8 +51,9 @@ cfg-if.workspace = true
 portable-atomic = { workspace = true, optional = true }
 portable_atomic_enum.workspace = true
 
-# We don't use it directly but we need to enable portable-atomic on it
+# We don't use these directly but we need to enable portable-atomic on them
 futures-util.workspace = true
+atomic-waker.workspace = true
 
 [build-dependencies]
 toml-cfg.workspace = true
@@ -141,7 +142,7 @@ log = [
   "esp32s3-hal?/log",
 ]
 
-portable-atomic = ["dep:portable-atomic", "portable_atomic_enum/portable-atomic", "futures-util/portable-atomic", "heapless/portable-atomic"]
+portable-atomic = ["dep:portable-atomic", "portable_atomic_enum/portable-atomic", "futures-util/portable-atomic", "atomic-waker/portable-atomic"]
 
 [package.metadata.docs.rs]
 features = ["esp32c3", "wifi", "ble", "async", "embassy-net", "esp32c3-hal/embassy-time-systick", "esp32c3-hal/default"]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -48,7 +48,7 @@ embassy-net = { workspace = true, optional = true }
 toml-cfg.workspace = true
 libm.workspace = true
 cfg-if.workspace = true
-portable-atomic = { workspace = true, optional = true }
+portable-atomic.workspace = true
 portable_atomic_enum.workspace = true
 
 # We don't use these directly but we need to enable portable-atomic on them
@@ -67,15 +67,14 @@ bleps = { workspace = true, features = ["async"] }
 embedded-hal-async.workspace = true
 log.workspace = true
 static_cell.workspace = true
-portable-atomic = { workspace = true, features = ["critical-section"] } # for tests/examples we use portable-atomic
 
 [features]
-default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4", "portable-atomic" ]
+default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4" ]
 
 # chip features
-esp32c2 = [ "esp32c2-hal", "esp-wifi-sys/esp32c2", "esp-println/esp32c2", "esp-backtrace/esp32c2", "embassy-executor/arch-riscv32" ]
-esp32c3 = [ "esp32c3-hal", "esp-wifi-sys/esp32c3", "esp-println/esp32c3", "esp-backtrace/esp32c3", "embassy-executor/arch-riscv32" ]
-esp32c6 = [ "esp32c6-hal", "esp-wifi-sys/esp32c6", "esp-println/esp32c6", "esp-backtrace/esp32c6", "embassy-executor/arch-riscv32" ]
+esp32c2 = [ "esp32c2-hal", "esp-wifi-sys/esp32c2", "esp-println/esp32c2", "esp-backtrace/esp32c2" ]
+esp32c3 = [ "esp32c3-hal", "esp-wifi-sys/esp32c3", "esp-println/esp32c3", "esp-backtrace/esp32c3" ]
+esp32c6 = [ "esp32c6-hal", "esp-wifi-sys/esp32c6", "esp-println/esp32c6", "esp-backtrace/esp32c6" ]
 esp32   = [ "esp32-hal",   "esp-wifi-sys/esp32",   "esp-println/esp32",   "esp-backtrace/esp32" ]
 esp32s2 = [ "esp32s2-hal", "esp-wifi-sys/esp32s2", "esp-println/esp32s2", "esp-backtrace/esp32s2" ]
 esp32s3 = [ "esp32s3-hal", "esp-wifi-sys/esp32s3", "esp-println/esp32s3", "esp-backtrace/esp32s3" ]
@@ -141,8 +140,6 @@ log = [
   "esp32s2-hal?/log",
   "esp32s3-hal?/log",
 ]
-
-portable-atomic = ["dep:portable-atomic", "portable_atomic_enum/portable-atomic", "futures-util/portable-atomic", "atomic-waker/portable-atomic"]
 
 [package.metadata.docs.rs]
 features = ["esp32c3", "wifi", "ble", "async", "embassy-net", "esp32c3-hal/embassy-time-systick", "esp32c3-hal/default"]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -38,7 +38,7 @@ linked_list_allocator = { workspace = true }
 embedded-io.workspace = true
 embedded-io-async = { workspace = true, optional = true }
 fugit.workspace = true
-heapless = { workspace = true, default-features = false, features = ["portable-atomic"] }
+heapless = { workspace = true, default-features = false }
 num-derive = { workspace = true }
 num-traits = { workspace = true, default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
@@ -48,7 +48,7 @@ embassy-net = { workspace = true, optional = true }
 toml-cfg.workspace = true
 libm.workspace = true
 cfg-if.workspace = true
-portable-atomic.workspace = true
+portable-atomic = { workspace = true, optional = true }
 portable_atomic_enum.workspace = true
 
 # We don't use it directly but we need to enable portable-atomic on it
@@ -66,10 +66,10 @@ bleps = { workspace = true, features = ["async"] }
 embedded-hal-async.workspace = true
 log.workspace = true
 static_cell.workspace = true
-portable-atomic = { workspace = true, features = ["critical-section"] }
+portable-atomic = { workspace = true, features = ["critical-section"] } # for tests/examples we use portable-atomic
 
 [features]
-default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4" ]
+default = [ "log", "ipv4", "tcp", "udp", "icmp", "igmp", "dns", "dhcpv4", "portable-atomic" ]
 
 # chip features
 esp32c2 = [ "esp32c2-hal", "esp-wifi-sys/esp32c2", "esp-println/esp32c2", "esp-backtrace/esp32c2", "embassy-executor/arch-riscv32" ]
@@ -140,6 +140,8 @@ log = [
   "esp32s2-hal?/log",
   "esp32s3-hal?/log",
 ]
+
+portable-atomic = ["dep:portable-atomic", "portable_atomic_enum/portable-atomic", "futures-util/portable-atomic", "heapless/portable-atomic"]
 
 [package.metadata.docs.rs]
 features = ["esp32c3", "wifi", "ble", "async", "embassy-net", "esp32c3-hal/embassy-time-systick", "esp32c3-hal/default"]

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -66,28 +66,29 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG as it might reduc
 
 ## Features
 
-| Feature        | Meaning                                                                                              |
-| -------------- | ---------------------------------------------------------------------------------------------------- |
-| wifi-logs      | logs the WiFi logs from the driver at log level `info`                                               |
-| dump-packets   | dumps packet info at log level `info`                                                                |
-| smoltcp        | Provide implementations of `smoltcp` traits                                                          |
-| utils          | Provide utilities for smoltcp initialization. Adds `smoltcp` dependency                              |
-| ble            | Enable BLE support                                                                                   |
-| wifi           | Enable WiFi support                                                                                  |
-| esp-now        | Enable [esp-now](https://www.espressif.com/en/solutions/low-power-solutions/esp-now) support         |
-| coex           | Enable WiFi-BLE coexistence support                                                                  |
-| ipv4           | IPv4 support. Includes `utils` feature                                                               |
-| ipv6           | IPv6 support. Includes `utils` feature                                                               |
-| tcp            | TCP socket support. Includes `ipv4` feature                                                          |
-| udp            | UDP socket support. Includes `ipv4` feature                                                          |
-| igmp           | IGMP (multicast) support. Includes `ipv4` feature                                                    |
-| dns            | DNS support. Includes `udp` feature                                                                  |
-| dhcpv4         | DHCPv4 support, both creating sockets and autoconfiguring network settings. Includes `utils` feature |
-| phy-enable-usb | See [USB-SERIAL-JTAG](#usb-serial-jtag) above                                                        |
-| ps-min-modem   | Enable minimum modem sleep. Only affects STA mode                                                    |
-| ps-max-modem   | Enable maximum modem sleep. Only affects STA mode                                                    |
-| log            | Route log output to the `log` crate                                                                  |
-| defmt          | Add `defmt::Format` implementation and output logs via `defmt`                                       |
+| Feature         | Meaning                                                                                              |
+| --------------- | ---------------------------------------------------------------------------------------------------- |
+| wifi-logs       | logs the WiFi logs from the driver at log level `info`                                               |
+| dump-packets    | dumps packet info at log level `info`                                                                |
+| smoltcp         | Provide implementations of `smoltcp` traits                                                          |
+| utils           | Provide utilities for smoltcp initialization. Adds `smoltcp` dependency                              |
+| ble             | Enable BLE support                                                                                   |
+| wifi            | Enable WiFi support                                                                                  |
+| esp-now         | Enable [esp-now](https://www.espressif.com/en/solutions/low-power-solutions/esp-now) support         |
+| coex            | Enable WiFi-BLE coexistence support                                                                  |
+| ipv4            | IPv4 support. Includes `utils` feature                                                               |
+| ipv6            | IPv6 support. Includes `utils` feature                                                               |
+| tcp             | TCP socket support. Includes `ipv4` feature                                                          |
+| udp             | UDP socket support. Includes `ipv4` feature                                                          |
+| igmp            | IGMP (multicast) support. Includes `ipv4` feature                                                    |
+| dns             | DNS support. Includes `udp` feature                                                                  |
+| dhcpv4          | DHCPv4 support, both creating sockets and autoconfiguring network settings. Includes `utils` feature |
+| phy-enable-usb  | See [USB-SERIAL-JTAG](#usb-serial-jtag) above                                                        |
+| ps-min-modem    | Enable minimum modem sleep. Only affects STA mode                                                    |
+| ps-max-modem    | Enable maximum modem sleep. Only affects STA mode                                                    |
+| log             | Route log output to the `log` crate                                                                  |
+| defmt           | Add `defmt::Format` implementation and output logs via `defmt`                                       |
+| portable-atomic | Enables polyfilling using `portable-atomic`. Disable if you use atomic emulation trap                |
 
 Note that not all features are available on every MCU. For example, `ble` (and thus, `coex`) is not available on ESP32-S2.
 

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -66,29 +66,28 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG as it might reduc
 
 ## Features
 
-| Feature         | Meaning                                                                                              |
-| --------------- | ---------------------------------------------------------------------------------------------------- |
-| wifi-logs       | logs the WiFi logs from the driver at log level `info`                                               |
-| dump-packets    | dumps packet info at log level `info`                                                                |
-| smoltcp         | Provide implementations of `smoltcp` traits                                                          |
-| utils           | Provide utilities for smoltcp initialization. Adds `smoltcp` dependency                              |
-| ble             | Enable BLE support                                                                                   |
-| wifi            | Enable WiFi support                                                                                  |
-| esp-now         | Enable [esp-now](https://www.espressif.com/en/solutions/low-power-solutions/esp-now) support         |
-| coex            | Enable WiFi-BLE coexistence support                                                                  |
-| ipv4            | IPv4 support. Includes `utils` feature                                                               |
-| ipv6            | IPv6 support. Includes `utils` feature                                                               |
-| tcp             | TCP socket support. Includes `ipv4` feature                                                          |
-| udp             | UDP socket support. Includes `ipv4` feature                                                          |
-| igmp            | IGMP (multicast) support. Includes `ipv4` feature                                                    |
-| dns             | DNS support. Includes `udp` feature                                                                  |
-| dhcpv4          | DHCPv4 support, both creating sockets and autoconfiguring network settings. Includes `utils` feature |
-| phy-enable-usb  | See [USB-SERIAL-JTAG](#usb-serial-jtag) above                                                        |
-| ps-min-modem    | Enable minimum modem sleep. Only affects STA mode                                                    |
-| ps-max-modem    | Enable maximum modem sleep. Only affects STA mode                                                    |
-| log             | Route log output to the `log` crate                                                                  |
-| defmt           | Add `defmt::Format` implementation and output logs via `defmt`                                       |
-| portable-atomic | Enables polyfilling using `portable-atomic`. Disable if you use atomic emulation trap                |
+| Feature        | Meaning                                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------------------- |
+| wifi-logs      | logs the WiFi logs from the driver at log level `info`                                               |
+| dump-packets   | dumps packet info at log level `info`                                                                |
+| smoltcp        | Provide implementations of `smoltcp` traits                                                          |
+| utils          | Provide utilities for smoltcp initialization. Adds `smoltcp` dependency                              |
+| ble            | Enable BLE support                                                                                   |
+| wifi           | Enable WiFi support                                                                                  |
+| esp-now        | Enable [esp-now](https://www.espressif.com/en/solutions/low-power-solutions/esp-now) support         |
+| coex           | Enable WiFi-BLE coexistence support                                                                  |
+| ipv4           | IPv4 support. Includes `utils` feature                                                               |
+| ipv6           | IPv6 support. Includes `utils` feature                                                               |
+| tcp            | TCP socket support. Includes `ipv4` feature                                                          |
+| udp            | UDP socket support. Includes `ipv4` feature                                                          |
+| igmp           | IGMP (multicast) support. Includes `ipv4` feature                                                    |
+| dns            | DNS support. Includes `udp` feature                                                                  |
+| dhcpv4         | DHCPv4 support, both creating sockets and autoconfiguring network settings. Includes `utils` feature |
+| phy-enable-usb | See [USB-SERIAL-JTAG](#usb-serial-jtag) above                                                        |
+| ps-min-modem   | Enable minimum modem sleep. Only affects STA mode                                                    |
+| ps-max-modem   | Enable maximum modem sleep. Only affects STA mode                                                    |
+| log            | Route log output to the `log` crate                                                                  |
+| defmt          | Add `defmt::Format` implementation and output logs via `defmt`                                       |
 
 Note that not all features are available on every MCU. For example, `ble` (and thus, `coex`) is not available on ESP32-S2.
 

--- a/esp-wifi/automated-tests/open_access_point.rs
+++ b/esp-wifi/automated-tests/open_access_point.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::AccessPoint(AccessPointConfiguration {
-        ssid: "esp-wifi".into(),
+        ssid: "esp-wifi".try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/automated-tests/test_connect.rs
+++ b/esp-wifi/automated-tests/test_connect.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
+        ssid: SSID.try_into().unwrap(),
         auth_method: AuthMethod::None,
         ..Default::default()
     });

--- a/esp-wifi/examples/access_point.rs
+++ b/esp-wifi/examples/access_point.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::AccessPoint(AccessPointConfiguration {
-        ssid: "esp-wifi".into(),
+        ssid: "esp-wifi".try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/examples/access_point_with_sta.rs
+++ b/esp-wifi/examples/access_point_with_sta.rs
@@ -75,12 +75,12 @@ fn main() -> ! {
 
     let client_config = Configuration::Mixed(
         ClientConfiguration {
-            ssid: SSID.into(),
-            password: PASSWORD.into(),
+            ssid: SSID.try_into().unwrap(),
+            password: PASSWORD.try_into().unwrap(),
             ..Default::default()
         },
         AccessPointConfiguration {
-            ssid: "esp-wifi".into(),
+            ssid: "esp-wifi".try_into().unwrap(),
             ..Default::default()
         },
     );

--- a/esp-wifi/examples/bench.rs
+++ b/esp-wifi/examples/bench.rs
@@ -66,8 +66,8 @@ fn main() -> ! {
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/examples/coex.rs
+++ b/esp-wifi/examples/coex.rs
@@ -65,8 +65,8 @@ fn main() -> ! {
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/examples/dhcp.rs
+++ b/esp-wifi/examples/dhcp.rs
@@ -55,8 +55,8 @@ fn main() -> ! {
     let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/examples/embassy_access_point.rs
+++ b/esp-wifi/examples/embassy_access_point.rs
@@ -172,7 +172,7 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::AccessPoint(AccessPointConfiguration {
-                ssid: "esp-wifi".into(),
+                ssid: "esp-wifi".try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/esp-wifi/examples/embassy_access_point_with_sta.rs
+++ b/esp-wifi/examples/embassy_access_point_with_sta.rs
@@ -82,12 +82,12 @@ async fn main(spawner: Spawner) -> ! {
 
     let client_config = Configuration::Mixed(
         ClientConfiguration {
-            ssid: SSID.into(),
-            password: PASSWORD.into(),
+            ssid: SSID.try_into().unwrap(),
+            password: PASSWORD.try_into().unwrap(),
             ..Default::default()
         },
         AccessPointConfiguration {
-            ssid: "esp-wifi".into(),
+            ssid: "esp-wifi".try_into().unwrap(),
             ..Default::default()
         },
     );

--- a/esp-wifi/examples/embassy_bench.rs
+++ b/esp-wifi/examples/embassy_bench.rs
@@ -124,8 +124,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/esp-wifi/examples/embassy_dhcp.rs
+++ b/esp-wifi/examples/embassy_dhcp.rs
@@ -144,8 +144,8 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
+                ssid: SSID.try_into().unwrap(),
+                password: PASSWORD.try_into().unwrap(),
                 ..Default::default()
             });
             controller.set_configuration(&client_config).unwrap();

--- a/esp-wifi/examples/static_ip.rs
+++ b/esp-wifi/examples/static_ip.rs
@@ -57,8 +57,8 @@ fn main() -> ! {
     let mut wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
 
     let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
+        ssid: SSID.try_into().unwrap(),
+        password: PASSWORD.try_into().unwrap(),
         ..Default::default()
     });
     let res = controller.set_configuration(&client_config);

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -5,8 +5,8 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -5,8 +5,13 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32.rs
@@ -5,13 +5,7 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -27,11 +21,11 @@ pub(crate) fn enable_wifi_power_domain() {
         let rtc_cntl = &*crate::hal::peripherals::RTC_CNTL::ptr();
 
         rtc_cntl
-            .dig_pwc
+            .dig_pwc()
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         rtc_cntl
-            .dig_iso
+            .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
 }
@@ -210,8 +204,9 @@ unsafe extern "C" fn phy_exit_critical(level: u32) {
 #[ram]
 #[no_mangle]
 unsafe extern "C" fn rtc_get_xtal() -> u32 {
-    trace!("rtc_get_xtal - just hardcoded value 40 for now");
-    40
+    use crate::hal::clock::Clock;
+    let xtal = crate::hal::rtc_cntl::RtcClock::get_xtal_freq();
+    xtal.mhz()
 }
 
 #[no_mangle]

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -5,8 +5,13 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -5,13 +5,7 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -144,6 +138,7 @@ pub(crate) unsafe fn phy_disable_clock() {
 
 #[no_mangle]
 pub extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
-    // JUST SUPPORT 40MHz XTAL for now
-    40
+    use crate::hal::clock::Clock;
+    let xtal = crate::hal::rtc_cntl::RtcClock::get_xtal_freq();
+    xtal.mhz() as i32
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c2.rs
@@ -5,8 +5,8 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -5,13 +5,7 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -45,18 +39,18 @@ pub(crate) fn enable_wifi_power_domain() {
         let syscon = &*crate::hal::peripherals::APB_CTRL::ptr();
 
         rtc_cntl
-            .dig_pwc
+            .dig_pwc()
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
 
         rtc_cntl
-            .dig_iso
+            .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -5,8 +5,13 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -5,8 +5,8 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -5,13 +5,7 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -5,8 +5,13 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c6.rs
@@ -5,8 +5,8 @@ use crate::compat::common::str_from_c;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -5,8 +5,8 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -5,8 +5,13 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s2.rs
@@ -5,13 +5,7 @@ use crate::hal::prelude::ram;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -43,18 +37,18 @@ pub(crate) fn enable_wifi_power_domain() {
         let syscon = &*crate::hal::peripherals::SYSCON::ptr();
 
         rtc_cntl
-            .dig_pwc
+            .dig_pwc()
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
 
         rtc_cntl
-            .dig_iso
+            .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -4,8 +4,13 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -4,13 +4,7 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 
@@ -50,18 +44,18 @@ pub(crate) fn enable_wifi_power_domain() {
         let syscon = &*crate::hal::peripherals::APB_CTRL::ptr();
 
         rtc_cntl
-            .dig_pwc
+            .dig_pwc()
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
         syscon
-            .wifi_rst_en
+            .wifi_rst_en()
             .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
 
         rtc_cntl
-            .dig_iso
+            .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
 }

--- a/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32s3.rs
@@ -4,8 +4,8 @@ use crate::common_adapter::RADIO_CLOCKS;
 use crate::hal::system::RadioClockController;
 use crate::hal::system::RadioPeripherals;
 
-use atomic_polyfill::AtomicU32;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 const SOC_PHY_DIG_REGS_MEM_SIZE: usize = 21 * 4;
 

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -7,10 +7,15 @@
 //! For more information see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_now.html
 
 use core::marker::PhantomData;
-use core::sync::atomic::Ordering;
 use core::{cell::RefCell, fmt::Debug};
 
-use portable_atomic::{AtomicBool, AtomicU8};
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicBool, AtomicU8, Ordering};
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -10,7 +10,7 @@ use core::marker::PhantomData;
 use core::sync::atomic::Ordering;
 use core::{cell::RefCell, fmt::Debug};
 
-use atomic_polyfill::{AtomicBool, AtomicU8};
+use portable_atomic::{AtomicBool, AtomicU8};
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -9,13 +9,7 @@
 use core::marker::PhantomData;
 use core::{cell::RefCell, fmt::Debug};
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicBool, AtomicU8, Ordering};
+use portable_atomic::{AtomicBool, AtomicU8, Ordering};
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -72,7 +72,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
     unsafe {
         // clear FROM_CPU_INTR3
         (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3
+            .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
     }
 
@@ -90,7 +90,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
 pub fn yield_task() {
     unsafe {
         (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3
+            .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
     }
 }

--- a/esp-wifi/src/timer/timer_esp32c6.rs
+++ b/esp-wifi/src/timer/timer_esp32c6.rs
@@ -23,10 +23,10 @@ pub fn setup_radio_isr() {
     // for some reason for this interrupt, mapping it to 0 doesn't deactivate it
     let interrupt_core0 = unsafe { &*peripherals::INTERRUPT_CORE0::PTR };
     interrupt_core0
-        .wifi_bb_intr_map
+        .wifi_bb_intr_map()
         .write(|w| w.wifi_bb_intr_map().variant(31));
     interrupt_core0
-        .modem_peri_timeout_intr_map
+        .modem_peri_timeout_intr_map()
         .write(|w| w.modem_peri_timeout_intr_map().variant(31));
 
     #[cfg(feature = "ble")]

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -1,6 +1,6 @@
-use atomic_polyfill::AtomicU32;
 use core::cell::RefCell;
 use core::sync::atomic::Ordering;
+use portable_atomic::AtomicU32;
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -1,12 +1,6 @@
 use core::cell::RefCell;
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -1,6 +1,12 @@
 use core::cell::RefCell;
-use core::sync::atomic::Ordering;
-use portable_atomic::AtomicU32;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicU32, Ordering};
 
 use critical_section::Mutex;
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -4,13 +4,19 @@ pub(crate) mod os_adapter;
 pub(crate) mod state;
 
 use core::ptr::addr_of;
-use core::sync::atomic::Ordering;
 use core::time::Duration;
 use core::{
     cell::{RefCell, RefMut},
     mem::MaybeUninit,
 };
-use portable_atomic::AtomicUsize;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+use atomic::{AtomicUsize, Ordering};
 
 use crate::common_adapter::*;
 use crate::esp_wifi_result;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -10,13 +10,7 @@ use core::{
     mem::MaybeUninit,
 };
 
-#[cfg(not(feature = "portable-atomic"))]
-use core::sync::atomic;
-
-#[cfg(feature = "portable-atomic")]
-use portable_atomic as atomic;
-
-use atomic::{AtomicUsize, Ordering};
+use portable_atomic::{AtomicUsize, Ordering};
 
 use crate::common_adapter::*;
 use crate::esp_wifi_result;

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -3,7 +3,6 @@
 pub(crate) mod os_adapter;
 pub(crate) mod state;
 
-use atomic_polyfill::AtomicUsize;
 use core::ptr::addr_of;
 use core::sync::atomic::Ordering;
 use core::time::Duration;
@@ -11,6 +10,7 @@ use core::{
     cell::{RefCell, RefMut},
     mem::MaybeUninit,
 };
+use portable_atomic::AtomicUsize;
 
 use crate::common_adapter::*;
 use crate::esp_wifi_result;

--- a/esp-wifi/src/wifi/os_adapter_esp32c2.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c2.rs
@@ -3,7 +3,7 @@ use crate::hal::{peripherals, riscv};
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() | mask));
     }
 }
@@ -11,7 +11,7 @@ pub(crate) fn chip_ints_on(mask: u32) {
 pub(crate) fn chip_ints_off(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() & !mask));
     }
 }

--- a/esp-wifi/src/wifi/os_adapter_esp32c3.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c3.rs
@@ -3,7 +3,7 @@ use crate::hal::{peripherals, riscv};
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() | mask));
     }
 }
@@ -11,7 +11,7 @@ pub(crate) fn chip_ints_on(mask: u32) {
 pub(crate) fn chip_ints_off(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() & !mask));
     }
 }

--- a/esp-wifi/src/wifi/os_adapter_esp32c6.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c6.rs
@@ -3,7 +3,7 @@ use crate::hal::{peripherals, riscv};
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
         (*peripherals::INTPRI::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() | mask));
     }
 }
@@ -11,7 +11,7 @@ pub(crate) fn chip_ints_on(mask: u32) {
 pub(crate) fn chip_ints_off(mask: u32) {
     unsafe {
         (*peripherals::INTPRI::PTR)
-            .cpu_int_enable
+            .cpu_int_enable()
             .modify(|r, w| w.bits(r.bits() & !mask));
     }
 }

--- a/esp-wifi/src/wifi/state.rs
+++ b/esp-wifi/src/wifi/state.rs
@@ -1,11 +1,11 @@
 use super::WifiEvent;
 
-use atomic_enum::atomic_enum;
 use core::sync::atomic::Ordering;
+use portable_atomic_enum::atomic_enum;
 
 /// Wifi interface state
 #[atomic_enum]
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WifiState {
     StaStarted,

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -72,7 +72,7 @@ impl<'a, MODE: WifiDeviceMode> WifiStack<'a, MODE> {
             network_config: RefCell::new(ipv4::Configuration::Client(
                 ipv4::ClientConfiguration::DHCP(ipv4::DHCPClientSettings {
                     //FIXME: smoltcp currently doesn't have a way of giving a hostname through DHCP
-                    hostname: Some("Espressif".into()),
+                    hostname: Some(unwrap!("Espressif".try_into().ok())),
                 }),
             )),
             ip_info: RefCell::new(None),


### PR DESCRIPTION
Blocked on the next esp-hal release. The PR keeps atomic emulation stuff enabled for ESP32-S2 because the old heapless doesn't know about xtensa and so it won't enable atomic-polyfill even with the `cas` feature enabled. Other than that, RISC-V targets should now be able to compile esp-wifi with the emulation trap disabled.

Closes #337
Closes #373