### PR TITLE
Tolerate leading v in version string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ static_cell = { version = "=1.2", features = ["nightly"] }
 
 embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }
-embassy-executor = { version = "0.3.0", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] }
+embassy-executor = { version = "=0.3.2", package = "embassy-executor", features = ["nightly", "executor-thread", "integrated-timers"] } # temporarily pin because we aren't ready for portable-atomic yet
 embassy-time = { version = "0.1.3", features = ["nightly"] }
 futures-util = { version = "0.3.28", default-features = false }
 esp-println = { version = "0.6.0" }

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), String> {
             .next()
             .unwrap();
 
-        let mut version = version.split('.');
+        let mut version = version.trim_start_matches('v').split('.');
 
         let major = version.next().unwrap().parse::<u32>().unwrap();
         let minor = version.next().unwrap().parse::<u32>().unwrap();


### PR DESCRIPTION
espressif's rustc started including a `v` in front of the version number with 1.74, like `rustc 1.74.0-nightly (bd6bb31df 2023-11-15) (v1.74.0.0)`