### PR TITLE
add "scan_with_config" method to sync WifiController, like for async

### DIFF
--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1336,7 +1336,7 @@ impl<'d> WifiController<'d> {
     }
 
     /// A blocking wifi network scan with caller-provided scanning options.
-    pub fn scan_with_config<const N: usize>(
+    pub fn scan_with_config_sync<const N: usize>(
         &mut self,
         config: ScanConfig<'_>,
     ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), WifiError> {
@@ -1614,7 +1614,7 @@ impl Wifi for WifiController<'_> {
     fn scan_n<const N: usize>(
         &mut self,
     ) -> Result<(heapless::Vec<AccessPointInfo, N>, usize), Self::Error> {
-        self.scan_with_config(Default::default())
+        self.scan_with_config_sync(Default::default())
     }
 
     /// Get the currently used configuration.


### PR DESCRIPTION
the default active scan parameters (min 10ms max 20ms) are way too quick in my environment. the async interface of `WifiController` has a `scan_with_config` method already so i just wrote the same for the sync interface

this PR is the simplest approach to fixing the problem, but i wonder if instead `scan_with_config()` should be added to the `Wifi` trait in `embedded_svc` alongside `scan_n()`. `ScanConfig` and `ScanTypeConfig` would also have to be moved. 

tangentially, i think the async interface can soon be added to the trait definition in stable rust in 1.75? https://github.com/rust-lang/rust/pull/115822