### PR TITLE
Don't require smoltcp as a dev dependency

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -63,7 +63,6 @@ futures-util.workspace = true
 bleps = { workspace = true, features = ["async"] }
 embedded-hal-async.workspace = true
 log.workspace = true
-smoltcp.workspace = true
 static_cell.workspace = true
 
 [features]
@@ -111,13 +110,13 @@ phy-enable-usb = []
 ps-min-modem = []
 ps-max-modem = []
 esp-now = [ "wifi" ]
-ipv6 = ["wifi", "utils", "smoltcp?/proto-ipv6"]
-ipv4 = ["wifi", "utils", "smoltcp?/proto-ipv4"]
-tcp = ["ipv4", "smoltcp?/socket-tcp"]
-udp = ["ipv4", "smoltcp?/socket-udp"]
-icmp = ["ipv4", "smoltcp?/socket-icmp"]
-igmp = ["ipv4", "smoltcp?/proto-igmp"]
-dns = ["udp", "smoltcp?/proto-dns", "smoltcp?/socket-dns"]
+ipv6   = ["wifi", "utils", "smoltcp?/proto-ipv6"]
+ipv4   = ["wifi", "utils", "smoltcp?/proto-ipv4"]
+tcp    = ["ipv4", "smoltcp?/socket-tcp"]
+udp    = ["ipv4", "smoltcp?/socket-udp"]
+icmp   = ["ipv4", "smoltcp?/socket-icmp"]
+igmp   = ["ipv4", "smoltcp?/proto-igmp"]
+dns    = ["udp",  "smoltcp?/proto-dns", "smoltcp?/socket-dns"]
 dhcpv4 = ["wifi", "utils", "smoltcp?/proto-dhcpv4", "smoltcp?/socket-dhcpv4"]
 defmt = [
   "dep:defmt",

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -70,6 +70,7 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG since it might re
 | -------------- | ---------------------------------------------------------------------------------------------------- |
 | wifi-logs      | logs the WiFi logs from the driver at log level info                                                 |
 | dump-packets   | dumps packet info at log level info                                                                  |
+| smoltcp        | Provide implementations of `smoltcp` traits                                                          |
 | utils          | Provide utilities for smoltcp initialization; adds `smoltcp` dependency                              |
 | ble            | Enable BLE support                                                                                   |
 | wifi           | Enable WiFi support                                                                                  |


### PR DESCRIPTION
My hope is that this change is enough to avoid enabling all the features in #352. We should probably try and reduce feature spaghetti around smoltcp/utils/wifi/etc. in the future.

smoltcp is already an optional dependency enabled by features, I don't think it needs to be unconditionally enabled for tests/examples