### PR TITLE
Remove embedded-svc feature

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -57,7 +57,6 @@ toml-cfg.workspace = true
 [dev-dependencies]
 esp-println = { workspace = true, features = ["log"] }
 esp-backtrace.workspace = true
-embedded-svc.workspace = true
 embassy-executor.workspace = true
 embassy-time.workspace = true
 futures-util.workspace = true
@@ -106,8 +105,7 @@ dump-packets = []
 smoltcp = [ "dep:smoltcp" ]
 utils = [ "smoltcp" ]
 enumset = []
-embedded-svc = [ "dep:enumset", "dep:embedded-svc" ]
-wifi = [ "embedded-svc" ]
+wifi = [ "dep:enumset", "dep:embedded-svc" ]
 ble = [ "esp32-hal?/bluetooth" ]
 phy-enable-usb = []
 ps-min-modem = []

--- a/esp-wifi/README.md
+++ b/esp-wifi/README.md
@@ -71,7 +71,6 @@ Don't use this feature if your are _not_ using USB-SERIAL-JTAG since it might re
 | wifi-logs      | logs the WiFi logs from the driver at log level info                                                 |
 | dump-packets   | dumps packet info at log level info                                                                  |
 | utils          | Provide utilities for smoltcp initialization; adds `smoltcp` dependency                              |
-| embedded-svc   | Provides a (very limited) implementation of the `embedded-svc` WiFi trait                            |        
 | ble            | Enable BLE support                                                                                   |
 | wifi           | Enable WiFi support                                                                                  |
 | esp-now        | Enable esp-now support                                                                               |

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -73,11 +73,7 @@ pub(crate) mod memory_fence;
 use critical_section;
 use timer::{get_systimer_count, ticks_to_millis};
 
-#[cfg(all(
-    feature = "embedded-svc",
-    feature = "wifi",
-    any(feature = "tcp", feature = "udp")
-))]
+#[cfg(all(feature = "wifi", any(feature = "tcp", feature = "udp")))]
 pub mod wifi_interface;
 
 /// Return the current systimer time in milliseconds

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -21,7 +21,6 @@ use crate::EspWifiInitialization;
 
 use critical_section::{CriticalSection, Mutex};
 
-#[cfg(feature = "embedded-svc")]
 use embedded_svc::wifi::{
     AccessPointConfiguration, AccessPointInfo, AuthMethod, ClientConfiguration, Configuration,
     Protocol, SecondaryChannel, Wifi,


### PR DESCRIPTION
embedded-svc is required for wifi to work and not used elsewhere, so I don't think we should keep the feature around