### PR TITLE
Update `rust-cache` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           default: true
           buildtargets: esp32
           ldproxy: false
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: check-fmt
         run: cargo fmt --check
@@ -55,7 +55,7 @@ jobs:
         with:
           default: true
           ldproxy: false
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: build
         run: cd esp-wifi && cargo b${{ matrix.chip }}


### PR DESCRIPTION
Currently we get
```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
in the logs - better not to wait until the jobs start failing because of this
