### PR TITLE
1.fix compile error for esp32c3 

### DIFF
--- a/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
+++ b/esp-wifi/src/common_adapter/common_adapter_esp32c3.rs
@@ -39,18 +39,18 @@ pub(crate) fn enable_wifi_power_domain() {
         let syscon = &*crate::hal::peripherals::APB_CTRL::ptr();
 
         rtc_cntl
-            .dig_pwc()
+            .dig_pwc
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         syscon
-            .wifi_rst_en()
+            .wifi_rst_en
             .modify(|r, w| w.bits(r.bits() | MODEM_RESET_FIELD_WHEN_PU));
         syscon
-            .wifi_rst_en()
+            .wifi_rst_en
             .modify(|r, w| w.bits(r.bits() & !MODEM_RESET_FIELD_WHEN_PU));
 
         rtc_cntl
-            .dig_iso()
+            .dig_iso
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
 }

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -72,7 +72,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
     unsafe {
         // clear FROM_CPU_INTR3
         (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3()
+            .cpu_intr_from_cpu_3
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
     }
 
@@ -90,7 +90,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
 pub fn yield_task() {
     unsafe {
         (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3()
+            .cpu_intr_from_cpu_3
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
     }
 }

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -77,8 +77,8 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
         #[cfg(not(feature = "esp32c2"))]
         (&*SystemPeripheral::PTR)
-        .cpu_intr_from_cpu_3
-        .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
+            .cpu_intr_from_cpu_3
+            .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
     }
 
     critical_section::with(|cs| {

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -75,7 +75,7 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
-        #[cfg(feature = "esp32c3")]
+        #[cfg(not(feature = "esp32c2"))]
         (&*SystemPeripheral::PTR)
         .cpu_intr_from_cpu_3
         .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
@@ -98,7 +98,7 @@ pub fn yield_task() {
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
-        #[cfg(feature = "esp32c3")]
+        #[cfg(not(feature = "esp32c2"))]
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -71,13 +71,13 @@ fn SYSTIMER_TARGET0(trap_frame: &mut TrapFrame) {
 fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
     unsafe {
         // clear FROM_CPU_INTR3
-        #[cfg(feature = "esp32c2")]
-        (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3()
-            .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
-        #[cfg(not(feature = "esp32c2"))]
+        #[cfg(feature = "esp32c3")]
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3
+            .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
+        #[cfg(not(feature = "esp32c3"))]
+        (&*SystemPeripheral::PTR)
+            .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
     }
 
@@ -94,13 +94,13 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
 
 pub fn yield_task() {
     unsafe {
-        #[cfg(feature = "esp32c2")]
-        (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3()
-            .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
-        #[cfg(not(feature = "esp32c2"))]
+        #[cfg(feature = "esp32c3")]
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3
+            .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
+        #[cfg(not(feature = "esp32c3"))]
+        (&*SystemPeripheral::PTR)
+            .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
     }
 }

--- a/esp-wifi/src/timer/riscv.rs
+++ b/esp-wifi/src/timer/riscv.rs
@@ -71,9 +71,14 @@ fn SYSTIMER_TARGET0(trap_frame: &mut TrapFrame) {
 fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
     unsafe {
         // clear FROM_CPU_INTR3
+        #[cfg(feature = "esp32c2")]
         (&*SystemPeripheral::PTR)
-            .cpu_intr_from_cpu_3
+            .cpu_intr_from_cpu_3()
             .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
+        #[cfg(feature = "esp32c3")]
+        (&*SystemPeripheral::PTR)
+        .cpu_intr_from_cpu_3
+        .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
     }
 
     critical_section::with(|cs| {
@@ -89,6 +94,11 @@ fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
 
 pub fn yield_task() {
     unsafe {
+        #[cfg(feature = "esp32c2")]
+        (&*SystemPeripheral::PTR)
+            .cpu_intr_from_cpu_3()
+            .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
+        #[cfg(feature = "esp32c3")]
         (&*SystemPeripheral::PTR)
             .cpu_intr_from_cpu_3
             .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());

--- a/esp-wifi/src/wifi/os_adapter_esp32c3.rs
+++ b/esp-wifi/src/wifi/os_adapter_esp32c3.rs
@@ -3,7 +3,7 @@ use crate::hal::{peripherals, riscv};
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable()
+            .cpu_int_enable
             .modify(|r, w| w.bits(r.bits() | mask));
     }
 }
@@ -11,7 +11,7 @@ pub(crate) fn chip_ints_on(mask: u32) {
 pub(crate) fn chip_ints_off(mask: u32) {
     unsafe {
         (*peripherals::INTERRUPT_CORE0::PTR)
-            .cpu_int_enable()
+            .cpu_int_enable
             .modify(|r, w| w.bits(r.bits() & !mask));
     }
 }


### PR DESCRIPTION
Fixed the following compile error

error[E0599]: no method named cpu_intr_from_cpu_3 found for reference &esp32c3::system::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\timer\riscv.rs:74:14
|
73 | / (&*SystemPeripheral::PTR)
74 | | .cpu_intr_from_cpu_3()
| | -^^^^^^^^^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named cpu_intr_from_cpu_3 found for reference &esp32c3::system::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\timer\riscv.rs:92:14
|
91 | / (&*SystemPeripheral::PTR)
92 | | .cpu_intr_from_cpu_3()
| | -^^^^^^^^^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named cpu_int_enable found for struct esp32c3::interrupt_core0::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\wifi\os_adapter_esp32c3.rs:6:14
|
5 | / (*peripherals::INTERRUPT_CORE0::PTR)
6 | | .cpu_int_enable()
| | -^^^^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named cpu_int_enable found for struct esp32c3::interrupt_core0::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\wifi\os_adapter_esp32c3.rs:14:14
|
13 | / (*peripherals::INTERRUPT_CORE0::PTR)
14 | | .cpu_int_enable()
| | -^^^^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named dig_pwc found for reference &esp32c3::rtc_cntl::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\common_adapter\common_adapter_esp32c3.rs:42:14
|
41 | / rtc_cntl
42 | | .dig_pwc()
| | -^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named wifi_rst_en found for reference &esp32c3::apb_ctrl::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\common_adapter\common_adapter_esp32c3.rs:46:14
|
45 | / syscon
46 | | .wifi_rst_en()
| | -^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named wifi_rst_en found for reference &esp32c3::apb_ctrl::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\common_adapter\common_adapter_esp32c3.rs:49:14
|
48 | / syscon
49 | | .wifi_rst_en()
| | -^^^^^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|

error[E0599]: no method named dig_iso found for reference &esp32c3::rtc_cntl::RegisterBlock in the current scope
--> D:\Rust.cargo\git\checkouts\esp-wifi-836f3b2af57fa847\d46dfc4\esp-wifi\src\common_adapter\common_adapter_esp32c3.rs:53:14
|
52 | / rtc_cntl
53 | | .dig_iso()
| | -^^^^^^^-- help: remove the arguments
| | ||
| |_____________|field, not a method
|