### PR TITLE
Correct mislead command in docs/examples.md when compile coex mode.

### DIFF
--- a/esp-wifi/docs/examples.md
+++ b/esp-wifi/docs/examples.md
@@ -8,6 +8,8 @@ To build these ensure you are in the `esp-wifi` directory (the inner one, which 
 ```
 cargo esp32c3 --release ...
 ```
+if you want to use wifi as STA mode, don't forget to add **env** variable in the front.
+`SSID=xxx PASSWORD=xxx cargo esp32c3 --example dhcp --release --features "wifi"`
 
 ### dhcp
 
@@ -54,7 +56,7 @@ cargo esp32c3 --release ...
 - does BLE advertising
 - coex support is still somewhat flaky
 
-`cargo $CHIP --example coex --release --features "wifi,ble"`
+`cargo $CHIP --example coex --release --features "wifi,ble,coex"`
 
 **NOTE:** Not currently available for the ESP32, ESP32-C2, ESP32-C6 or ESP32-S2
 


### PR DESCRIPTION
The command to compile didn't work in 'coex' mode. so I corrected it.