### PR TITLE
Fix the extcap

### DIFF
--- a/extras/esp-wifishark/README.md
+++ b/extras/esp-wifishark/README.md
@@ -2,7 +2,7 @@
 
 This is an extcap to be used with esp-wifi and the `dump-packets` feature.
 
-To use it build via `cargo --release` and copy the resulting executable to the Wireshark's `extcap` folder.
+To use it build via `cargo build --release` and copy the resulting executable to the Wireshark's `extcap` folder.
 
 Then you should see two new capture interfaces in Wireshark
 - esp-wifi HCI capture (for Bluetooth HCI)

--- a/extras/esp-wifishark/src/main.rs
+++ b/extras/esp-wifishark/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
                             let end = line.find("]").unwrap();
                             let line = line[start..end].to_string();
                             for hex in line.split(", ") {
-                                let byte = u8::from_str_radix(hex, 16).unwrap();
+                                let byte = u8::from_str_radix(hex, 10).unwrap();
                                 packet.push(byte);
                             }
                         }


### PR DESCRIPTION
#252 accidentally broke the Wireshark extcap by changing the dumped frames to decimal - this is a fix
