### PR TITLE
Bump esp-hal versions, patch embassy-net

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ debug = true
 
 [workspace.dependencies]
 defmt = "=0.3.5"
-esp32c3-hal = { version = "0.13.0", default-features = false }
-esp32c2-hal = { version = "0.11.0", default-features = false }
-esp32c6-hal = { version = "0.6.0",  default-features = false }
-esp32h2-hal = { version = "0.4.0", default-features = false }
-esp32-hal   = { version = "0.16.0", default-features = false }
-esp32s3-hal = { version = "0.13.0", default-features = false }
-esp32s2-hal = { version = "0.13.0", default-features = false }
+esp32c3-hal = { version = "0.14.0", default-features = false }
+esp32c2-hal = { version = "0.12.0", default-features = false }
+esp32c6-hal = { version = "0.7.0",  default-features = false }
+esp32h2-hal = { version = "0.5.0", default-features = false }
+esp32-hal   = { version = "0.17.0", default-features = false }
+esp32s3-hal = { version = "0.14.0", default-features = false }
+esp32s2-hal = { version = "0.14.0", default-features = false }
 smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
 portable-atomic = { version = "1.5", default-features = false }
@@ -37,32 +37,25 @@ heapless = { version = "0.7.16", default-features = false }
 num-derive = { version = "0.4" }
 num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }
-embassy-sync = { version = "0.4.0" }
+embassy-sync = { version = "0.5.0" }
 embassy-futures = { version = "0.1.0" }
 toml-cfg = "0.1.3"
 libm = "0.2.7"
 cfg-if = "1.0.0"
 static_cell = { version = "2.0", features = ["nightly"] }
 
-embassy-net = { version = "0.2.1", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.2.1", features = ["tcp", "udp", "dhcpv4", "medium-ethernet"] }
 bleps = { git = "https://github.com/bjoernQ/bleps", package = "bleps", rev = "0db8fcb", features = ["macros"] }
-embassy-executor = { version = "0.3.3", package = "embassy-executor", features = ["nightly", "integrated-timers"] }
-embassy-time = { version = "0.1.3", features = ["nightly"] }
+embassy-executor = { version = "0.4.0", package = "embassy-executor", features = ["nightly", "integrated-timers"] }
+embassy-time = { version = "0.2.0" }
 esp-println = { version = "0.7.0" }
 esp-backtrace = { version = "0.9.0", features = ["panic-handler", "exception-handler", "print-uart"] }
-embedded-hal-async = { version = "1.0.0-rc.1" }
+embedded-hal-async = { version = "1.0.0-rc.2" }
 embedded-io-async = { version = "0.6.0" }
 
 futures-util = { version = "0.3.28", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on AtomicWaker even though we don't use it
 atomic-waker = { version = "1.1.2", default-features = false, features = ["portable-atomic"] } # need this to activate portable-atomic on AtomicWaker used by embedded-svc even though we don't use it
 
-# portable-atomic compatible esp-hal revisions
 [patch.crates-io]
-esp32-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32c2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32c6-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32h2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32s2-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp32s3-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal.git", rev = "22f14fd" }
+embassy-net = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-net", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-time", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,7 @@ atomic-waker = { version = "1.1.2", default-features = false, features = ["porta
 [patch.crates-io]
 embassy-net = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-net", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-time", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-executor", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-executor-macros = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-executor-macros", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-sync", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", package = "embassy-futures", rev = "14f41a71b6ea9dedb4ee5b9c741fe10575772c7d"}

--- a/esp-wifi/examples/bench.rs
+++ b/esp-wifi/examples/bench.rs
@@ -120,18 +120,18 @@ fn main() -> ! {
     let mut tx_buffer = [0u8; TX_BUFFER_SIZE];
     let mut socket = wifi_stack.get_socket(&mut rx_buffer, &mut tx_buffer);
 
-    let delay = hal::Delay::new(&clocks);
+    let mut delay = hal::Delay::new(&clocks);
 
     loop {
         test_download(server_address, &mut socket);
-        delay.delay(3_000_000);
+        delay.delay_ms(3_000u32);
         socket.work();
         test_upload(server_address, &mut socket);
         socket.work();
-        delay.delay(3_000_000);
+        delay.delay_ms(3_000u32);
         test_upload_download(server_address, &mut socket);
         socket.work();
-        delay.delay(3_000_000);
+        delay.delay_ms(3_000u32);
     }
 }
 

--- a/run_tests.bat
+++ b/run_tests.bat
@@ -5,6 +5,7 @@ mkdir tmp\esp32s3
 mkdir tmp\esp32c2
 mkdir tmp\esp32c3
 mkdir tmp\esp32c6
+mkdir tmp\esp32h2
 
 cd esp-wifi
 cargo +esp build --release --example esp_now_broadcaster --target xtensa-esp32-none-elf --features esp32,esp32-hal/default,esp32-hal/embassy-time-timg0,esp32-hal/embassy-executor-thread,wifi,esp-now
@@ -75,13 +76,17 @@ cargo +nightly build --release --example test_ble --target riscv32imac-unknown-n
 copy ..\target\riscv32imac-unknown-none-elf\release\examples\test_ble ..\tmp\esp32h2
 
 cd ..\tmp
-echo "Connect ESP32, ESP32-C2, ESP32-C3, ESP32-C6, ESP32-H2"
+echo "Connect ESP32, ESP32-C2, ESP32-C3, ESP32-C6"
 pause
 esp-testrun --esp32=esp32 --esp32c2=esp32c2 --esp32c3=esp32c3 --esp32c6=esp32c6
 
 echo "Connect ESP32, ESP32-S2, ESP32-S3, ESP32-C3"
 pause
 esp-testrun --esp32=esp32 --esp32s2=esp32s2 --esp32s3=esp32s3 --esp32c3=esp32c3
+
+echo "Connect ESP32-H2"
+pause
+esp-testrun --esp32h2=esp32h2
 
 cd ..
 rd /q /s tmp


### PR DESCRIPTION
Use the currently released HALs - for now we need to patch embassy-net so we need to wait releasing a new version until embassy-net (which needs updated smoltcp)

At least we could now use this in esp-template (still need to patch embassy-net there, then)
