### PR TITLE
Avoid overwriting HCI buffer until sent

### DIFF
--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -596,8 +596,7 @@ pub fn send_hci(data: &[u8]) {
             }
 
             // make sure the packet buffer doesn't get touched until sent
-            while !PACKET_SENT.load(Ordering::Relaxed) {
-            }
+            while !PACKET_SENT.load(Ordering::Relaxed) {}
         }
 
         hci_out.reset();

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -1,6 +1,7 @@
 use core::{cell::RefCell, ptr::addr_of};
 
 use critical_section::Mutex;
+use portable_atomic::{AtomicBool, Ordering};
 
 use crate::ble::btdm::ble_os_adapter_chip_specific::{osi_funcs_s, G_OSI_FUNCS};
 use crate::ble::HciOutCollector;
@@ -30,6 +31,8 @@ pub struct ReceivedPacket {
 
 static BT_INTERNAL_QUEUE: Mutex<RefCell<SimpleQueue<[u8; 8], 10>>> =
     Mutex::new(RefCell::new(SimpleQueue::new()));
+
+static PACKET_SENT: AtomicBool = AtomicBool::new(true);
 
 #[repr(C)]
 struct vhci_host_callback_s {
@@ -64,6 +67,8 @@ static VHCI_HOST_CALLBACK: vhci_host_callback_s = vhci_host_callback_s {
 
 extern "C" fn notify_host_send_available() {
     trace!("notify_host_send_available");
+
+    PACKET_SENT.store(true, Ordering::Relaxed);
 }
 
 extern "C" fn notify_host_recv(data: *mut u8, len: u16) -> i32 {
@@ -581,12 +586,17 @@ pub fn send_hci(data: &[u8]) {
                     continue;
                 }
 
+                PACKET_SENT.store(false, Ordering::Relaxed);
                 API_vhci_host_send_packet(packet.as_ptr() as *const u8, packet.len() as u16);
                 trace!("sent vhci host packet");
 
                 dump_packet_info(packet);
 
                 break;
+            }
+
+            // make sure the packet buffer doesn't get touched until sent
+            while !PACKET_SENT.load(Ordering::Relaxed) {
             }
         }
 


### PR DESCRIPTION
When implementing an BLE HID device it turned out that for BTDM based drivers we shouldn't touch the packet passed to `API_vhci_host_send_packet` until it's sent

`API_vhci_host_check_send_available` doesn't seem to be suitable for that - for an easy fix this uses the `notify_host_send_available` callback to toggle a flag which seems to fix the issue

NPL based drivers seem to copy the packet in their send function and are not affected

If this ever turns out to become a performance problem, we can implement something more advanced but for now it seems to be good enough
