### PR TITLE
chore: bump heapless and smoltcp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ esp32h2-hal = { version = "0.5.0", default-features = false }
 esp32-hal   = { version = "0.17.0", default-features = false }
 esp32s3-hal = { version = "0.14.0", default-features = false }
 esp32s2-hal = { version = "0.14.0", default-features = false }
-smoltcp = { version = "0.10.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
+smoltcp = { version = "0.11.0", default-features=false, features = ["medium-ethernet", "socket-raw"] }
 critical-section = "1.1.1"
 portable-atomic = { version = "1.5", default-features = false }
 portable_atomic_enum = { version = "0.3.0", features = ["portable-atomic"] }
 log = "0.4.20"
-embedded-svc = { version = "0.26.1", default-features = false, features = [] }
+embedded-svc = { version = "0.26.4", default-features = false, features = [] }
 enumset = { version = "1.1.3", default-features = false }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 embedded-io = "0.6.1"
 fugit = "0.3.7"
-heapless = { version = "0.7.16", default-features = false }
+heapless = { version = "0.8.0", default-features = false, features = ["portable-atomic"] }
 num-derive = { version = "0.4" }
 num-traits = { version = "0.2", default-features = false }
 esp-wifi-sys = { version = "0.1.0", path = "../esp-wifi-sys" }

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1266,7 +1266,7 @@ fn convert_ap_info(record: &include::wifi_ap_record_t) -> AccessPointInfo {
         },
         signal_strength: record.rssi,
         protocols: EnumSet::empty(), // TODO
-        auth_method: AuthMethod::from_raw(record.authmode),
+        auth_method: Some(AuthMethod::from_raw(record.authmode)),
     }
 }
 


### PR DESCRIPTION
Updates smoltcp, embedded-svc, and heapless to their latest versions (since smoltcp no longer uses heapless 0.7 either)

Note that I have had to add the `portable-atomics` feature to heapless but that it is also selected on `portable_atomic_enum` so I assume that this is OK

edit: This needs a new release of embedded-svc. I will update when I get that merged.