### PR TITLE
Performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Users don't need embedded-svc to control wifi anymore. The wifi trait is optionally implemented now. (#429)
+- Better network performance by forced yielding of the task when buffers are full / empty. (#430)
 
 ### Removed
 

--- a/esp-wifi/examples/embassy_bench.rs
+++ b/esp-wifi/examples/embassy_bench.rs
@@ -13,8 +13,8 @@ use examples_util::hal;
 use embassy_time::{with_timeout, Duration, Timer};
 use esp_backtrace as _;
 use esp_println::println;
-use esp_wifi::wifi::{ClientConfiguration, Configuration};
-use esp_wifi::wifi::{WifiApDevice, WifiController, WifiDevice, WifiEvent, WifiState};
+use esp_wifi::wifi::{ClientConfiguration, Configuration, WifiStaDevice};
+use esp_wifi::wifi::{WifiController, WifiDevice, WifiEvent, WifiState};
 use esp_wifi::{initialize, EspWifiInitFor};
 use hal::clock::ClockControl;
 use hal::Rng;
@@ -60,7 +60,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let wifi = peripherals.WIFI;
     let (wifi_interface, controller) =
-        esp_wifi::wifi::new_with_mode(&init, wifi, WifiApDevice).unwrap();
+        esp_wifi::wifi::new_with_mode(&init, wifi, WifiStaDevice).unwrap();
 
     let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
     embassy::init(&clocks, timer_group0);
@@ -146,7 +146,7 @@ async fn connection(mut controller: WifiController<'static>) {
 }
 
 #[embassy_executor::task]
-async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiApDevice>>) {
+async fn net_task(stack: &'static Stack<WifiDevice<'static, WifiStaDevice>>) {
     stack.run().await
 }
 

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -452,6 +452,7 @@ impl<'a, MODE: WifiDeviceMode> WifiStack<'a, MODE> {
                     sockets,
                 )
             }) {
+                crate::timer::yield_task();
                 break;
             }
         }
@@ -725,7 +726,9 @@ impl<'s, 'n: 's, MODE: WifiDeviceMode> Read for Socket<'s, 'n, MODE> {
             use smoltcp::socket::tcp::RecvError;
 
             loop {
-                interface.poll(timestamp(), device, sockets);
+                if interface.poll(timestamp(), device, sockets) == false {
+                    crate::timer::yield_task();
+                }
                 let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
 
                 match socket.recv_slice(buf) {
@@ -745,11 +748,14 @@ impl<'s, 'n: 's, MODE: WifiDeviceMode> Write for Socket<'s, 'n, MODE> {
         loop {
             let (may_send, is_open, can_send) =
                 self.network.with_mut(|interface, device, sockets| {
-                    interface.poll(
+                    if interface.poll(
                         Instant::from_millis((self.network.current_millis_fn)() as i64),
                         device,
                         sockets,
-                    );
+                    ) == false
+                    {
+                        crate::timer::yield_task();
+                    }
 
                     let socket = sockets.get_mut::<TcpSocket>(self.socket_handle);
 
@@ -796,6 +802,7 @@ impl<'s, 'n: 's, MODE: WifiDeviceMode> Write for Socket<'s, 'n, MODE> {
             });
 
             if let false = res {
+                crate::timer::yield_task();
                 break;
             }
         }


### PR DESCRIPTION
This is based on the idea in #413 but this also works for async since the decision to yield from the active task is done at a lower level. To attribute the user who came up with the original idea I included that commit.

Here are some figures using ESP32-C6 with this `cfg.toml`
```toml
[esp-wifi]
rx_queue_size = 32
tx_queue_size = 3
static_rx_buf_num = 16
dynamic_rx_buf_num = 32
ampdu_rx_enable = 0
ampdu_tx_enable = 0
rx_ba_win = 32
max_burst_size = 6
heap_size = 86000
```

Using `embassy_bench.rs` I got these results (with a lot of RF noise, connected the ESP32-C6 to my laptop's hotspot)
```text
original
Testing download...
connecting to Address([192, 168, 137, 1]):4321...
connected, testing...
download: 410 kB/s
Testing upload...
connecting to Address([192, 168, 137, 1]):4322...
connected, testing...
upload: 210 kB/s
Testing upload+download...
connecting to Address([192, 168, 137, 1]):4323...
connected, testing...
upload+download: 307 kB/s

Reply from 192.168.137.143: Bytes=32 Time=31ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=33ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=34ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=33ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=54ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=40ms TTL=64


with these changes
connecting to Address([192, 168, 137, 1]):4321...
connected, testing...
download: 1046 kB/s
Testing upload...
connecting to Address([192, 168, 137, 1]):4322...
connected, testing...
upload: 1823 kB/s
Testing upload+download...
connecting to Address([192, 168, 137, 1]):4323...
connected, testing...
upload+download: 1154 kB/s


Reply from 192.168.137.143: Bytes=32 Time=1ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=3ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=2ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=1ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=4ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=2ms TTL=64
Reply from 192.168.137.143: Bytes=32 Time=5ms TTL=64
```

This also fixes the `embassy_bench.rs` exampe.
