### PR TITLE
Fix a compile error when smoltcp can return more than 1 DNS result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fix compile error when using smoltcp `DNS_MAX_RESULT_COUNT` values other than 1
 
 ### Changed
 

--- a/esp-wifi/src/wifi_interface.rs
+++ b/esp-wifi/src/wifi_interface.rs
@@ -374,7 +374,8 @@ impl<'a, MODE: WifiDeviceMode> WifiStack<'a, MODE> {
         &self,
         name: &str,
         query_type: DnsQueryType,
-    ) -> Result<heapless::Vec<IpAddress, 1>, WifiStackError> {
+    ) -> Result<heapless::Vec<IpAddress, { smoltcp::config::DNS_MAX_RESULT_COUNT }>, WifiStackError>
+    {
         use smoltcp::socket::dns;
 
         match query_type {


### PR DESCRIPTION
Update the WifiStack::dns_query() return type to match the type returned by smoltcp, rather than assuming the result size is always 1.