### PR TITLE
update to compile with latest esp-hal git main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- update with Timer and peripheral naming changes in `esp-hal`
+
 ### Changed
 
 ### Removed

--- a/esp-wifi/src/common_adapter/mod.rs
+++ b/esp-wifi/src/common_adapter/mod.rs
@@ -12,8 +12,8 @@ use crate::compat::timer_compat::*;
 use crate::hal;
 
 use esp_wifi_sys::include::timespec;
+use hal::peripherals::RADIO_CLK;
 use hal::rng::Rng;
-use hal::system::RadioClockControl;
 
 use hal::macros::ram;
 
@@ -37,13 +37,13 @@ pub(crate) mod phy_init_data;
 
 pub(crate) static mut RANDOM_GENERATOR: Option<Rng> = None;
 
-pub(crate) static mut RADIO_CLOCKS: Option<RadioClockControl> = None;
+pub(crate) static mut RADIO_CLOCKS: Option<RADIO_CLK> = None;
 
 pub(crate) fn init_rng(rng: Rng) {
     unsafe { RANDOM_GENERATOR = Some(core::mem::transmute(rng)) };
 }
 
-pub(crate) fn init_radio_clock_control(rcc: RadioClockControl) {
+pub(crate) fn init_radio_clock_control(rcc: RADIO_CLK) {
     unsafe { RADIO_CLOCKS = Some(core::mem::transmute(rcc)) };
 }
 

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -27,10 +27,10 @@ use esp_hal as hal;
 use hal::systimer::{Alarm, Target};
 
 use common_adapter::init_radio_clock_control;
-use hal::system::RadioClockController;
 
 use fugit::MegahertzU32;
 use hal::clock::Clocks;
+use hal::system::RadioClockController;
 use linked_list_allocator::Heap;
 #[cfg(feature = "wifi")]
 use wifi::WifiError;
@@ -160,7 +160,7 @@ pub(crate) type EspWifiTimer = Alarm<Target, esp_hal::Blocking, 0>;
 
 #[cfg(any(esp32, esp32s3, esp32s2))]
 pub(crate) type EspWifiTimer =
-    hal::timer::Timer<hal::timer::Timer0<hal::peripherals::TIMG1>, esp_hal::Blocking>;
+    hal::timer::timg::Timer<hal::timer::timg::Timer0<hal::peripherals::TIMG1>, esp_hal::Blocking>;
 
 #[derive(Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -237,7 +237,7 @@ pub fn initialize(
     init_for: EspWifiInitFor,
     timer: EspWifiTimer,
     rng: hal::rng::Rng,
-    radio_clocks: hal::system::RadioClockControl,
+    radio_clocks: hal::peripherals::RADIO_CLK,
     clocks: &Clocks,
 ) -> Result<EspWifiInitialization, InitializationError> {
     #[cfg(any(esp32, esp32s3, esp32s2))]

--- a/esp-wifi/src/timer/xtensa.rs
+++ b/esp-wifi/src/timer/xtensa.rs
@@ -9,7 +9,7 @@ use crate::{
         interrupt,
         peripherals::{self, TIMG1},
         prelude::*,
-        timer::{Timer, Timer0},
+        timer::timg::{Timer, Timer0},
         trapframe::TrapFrame,
         xtensa_lx, xtensa_lx_rt,
     },


### PR DESCRIPTION
A few changes in esp-hal main prevents compilation - these are updated here.

Merging this requires a patch "esp-hal" to a git version to use. (but then - they are already using a git version of this already....)

Tested on:
    esp32s3 - wifi only