### PR TITLE
Remove direct embedded-hal v0.2 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
+- Removed embedded-hal v0.2 dependency
 
 ## [0.5.1] - 2024-04-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ enumset = { version = "1.1.3", default-features = false }
 linked_list_allocator = { version = "0.10.5", default-features = false, features = [
     "const_mut_refs",
 ] }
-embedded-hal = { version = "0.2.4", default-features = false }
 embedded-io = { version = "0.6.1", default-features = false }
 fugit = "0.3.7"
 heapless = { version = "0.8", default-features = false, features = [

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -27,7 +27,6 @@ esp-hal = { workspace = true }
 smoltcp = { workspace = true, optional = true }
 critical-section.workspace = true
 log = { workspace = true, optional = true }
-embedded-hal = { workspace = true }
 embedded-svc = { workspace = true, optional = true }
 enumset = { workspace = true, optional = true }
 linked_list_allocator = { workspace = true }


### PR DESCRIPTION
As far as I can tell this is not needed and pulls in the old version of embedded-hal.