### PR TITLE
Prepare to release 0.8.0

### DIFF
--- a/esp-wifi-sys/Cargo.toml
+++ b/esp-wifi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "esp-wifi-sys"
-version     = "0.7.1"
+version     = "0.8.0"
 edition     = "2021"
 authors     = ["The ESP-RS team"]
 description = "Bindings to Espressif's WiFi and Bluetooth low-level drivers"
@@ -12,7 +12,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
 log   = { version = "0.4.25", optional = true }
-defmt = { version = "0.3.10", optional = true }
+defmt = { version = "1.0.1", optional = true }
 
 [build-dependencies]
 anyhow = "1.0.95"


### PR DESCRIPTION
Prepares the release so we can use a properly released version when updating esp-radio