### PR TITLE
use VaList instead of VaListImpl (nightly update)

### DIFF
--- a/esp-wifi-sys-esp32/src/lib.rs
+++ b/esp-wifi-sys-esp32/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32c2/src/lib.rs
+++ b/esp-wifi-sys-esp32c2/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32c3/src/lib.rs
+++ b/esp-wifi-sys-esp32c3/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32c5/src/lib.rs
+++ b/esp-wifi-sys-esp32c5/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32c6/src/lib.rs
+++ b/esp-wifi-sys-esp32c6/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32c61/src/lib.rs
+++ b/esp-wifi-sys-esp32c61/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32h2/src/lib.rs
+++ b/esp-wifi-sys-esp32h2/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32s2/src/lib.rs
+++ b/esp-wifi-sys-esp32s2/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {

--- a/esp-wifi-sys-esp32s3/src/lib.rs
+++ b/esp-wifi-sys-esp32s3/src/lib.rs
@@ -39,7 +39,7 @@ pub mod log {
     pub unsafe extern "C" fn syslog(
         _priority: u32,
         format: *const u8,
-        args: core::ffi::VaListImpl,
+        args: core::ffi::VaList,
     ) {
         #[allow(clashing_extern_declarations)]
         extern "C" {


### PR DESCRIPTION
I haven't actually tested whether the logs still work, but they should do.

Required for https://github.com/esp-rs/esp-hal/pull/5110