### PR TITLE
Add bindgen generated derive(PartialEq) to structs in include.rs

### DIFF
--- a/esp-wifi-sys-esp32/src/include.rs
+++ b/esp-wifi-sys-esp32/src/include.rs
@@ -1854,7 +1854,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1863,14 +1863,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -1967,7 +1967,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1977,7 +1977,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1990,7 +1990,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1998,7 +1998,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2006,7 +2006,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2070,7 +2070,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2080,7 +2080,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2088,7 +2088,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2111,7 +2111,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3361,19 +3361,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4114,7 +4114,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4310,7 +4310,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4319,7 +4319,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4328,7 +4328,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4337,7 +4337,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4360,7 +4360,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4421,7 +4421,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4486,7 +4486,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4838,7 +4838,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4847,7 +4847,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5289,7 +5289,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5314,7 +5314,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5543,14 +5543,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5594,7 +5594,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5611,7 +5611,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5710,7 +5710,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5731,7 +5731,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5778,7 +5778,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5885,7 +5885,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5992,7 +5992,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6009,7 +6009,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6020,7 +6020,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6031,7 +6031,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6217,7 +6217,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6228,7 +6228,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6245,7 +6245,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6260,7 +6260,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6269,7 +6269,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6290,7 +6290,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6298,7 +6298,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6307,7 +6307,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6318,7 +6318,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6331,7 +6331,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6340,14 +6340,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6376,7 +6376,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6395,7 +6395,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6426,7 +6426,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6441,7 +6441,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6454,7 +6454,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6471,7 +6471,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6480,7 +6480,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6667,7 +6667,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6688,14 +6688,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6709,7 +6709,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6792,7 +6792,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6801,7 +6801,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6816,7 +6816,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6837,7 +6837,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6859,14 +6859,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -6876,7 +6876,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 28usize]>,
@@ -7194,7 +7194,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7223,7 +7223,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7248,7 +7248,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7679,7 +7679,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7706,7 +7706,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7771,7 +7771,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8284,7 +8284,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8303,7 +8303,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8349,7 +8349,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8374,7 +8374,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8391,7 +8391,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8401,7 +8401,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8409,7 +8409,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8779,7 +8779,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9173,7 +9173,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9190,7 +9190,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9294,13 +9294,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9417,7 +9417,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9476,7 +9476,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9588,7 +9588,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9748,7 +9748,7 @@ pub const esp_ble_sca_t_ESP_BLE_SCA_20PPM: esp_ble_sca_t = 7;
 pub type esp_ble_sca_t = crate::c_types::c_uint;
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Bluetooth Controller task stack size in bytes"]
     pub controller_task_stack_size: u16,
@@ -9973,7 +9973,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< Callback to notify the Host that the Controller is ready to receive the HCI data"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10042,7 +10042,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _spin_lock_create:
@@ -10110,7 +10110,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10298,7 +10298,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10317,7 +10317,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10328,7 +10328,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10365,7 +10365,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10486,7 +10486,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32/src/include.rs
+++ b/esp-wifi-sys-esp32/src/include.rs
@@ -1854,7 +1854,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1863,14 +1863,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -1967,7 +1967,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1977,7 +1977,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1990,7 +1990,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1998,7 +1998,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2006,7 +2006,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2070,7 +2070,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2080,7 +2080,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2088,7 +2088,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2111,7 +2111,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3361,19 +3361,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4114,7 +4114,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4310,7 +4310,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4319,7 +4319,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4328,7 +4328,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4337,7 +4337,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4360,7 +4360,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4421,7 +4421,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4486,7 +4486,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4717,7 +4717,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -4838,7 +4838,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4847,7 +4847,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -4856,7 +4856,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -4876,7 +4876,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -4885,7 +4885,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -4926,7 +4926,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -5289,7 +5289,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5314,7 +5314,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5543,14 +5543,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5594,7 +5594,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5611,7 +5611,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5710,7 +5710,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5731,7 +5731,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5778,7 +5778,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5885,7 +5885,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5992,7 +5992,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6009,7 +6009,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6020,7 +6020,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6031,7 +6031,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6217,7 +6217,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6228,7 +6228,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6245,7 +6245,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6260,7 +6260,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6269,7 +6269,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6290,7 +6290,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6298,7 +6298,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6307,7 +6307,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6318,7 +6318,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6331,7 +6331,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6340,14 +6340,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6376,7 +6376,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6395,7 +6395,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6426,7 +6426,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6441,7 +6441,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6454,7 +6454,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6471,7 +6471,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6480,7 +6480,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6667,7 +6667,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6688,14 +6688,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6709,7 +6709,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6792,7 +6792,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6801,7 +6801,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6816,7 +6816,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6837,7 +6837,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6859,14 +6859,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -6876,7 +6876,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 28usize]>,
@@ -7194,7 +7194,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7223,7 +7223,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7248,7 +7248,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7679,7 +7679,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7706,7 +7706,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7771,7 +7771,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8284,7 +8284,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8303,7 +8303,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8349,7 +8349,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8374,7 +8374,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8391,7 +8391,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8401,7 +8401,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8409,7 +8409,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8779,7 +8779,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9173,7 +9173,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9190,7 +9190,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9294,13 +9294,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9417,7 +9417,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9476,7 +9476,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9588,7 +9588,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9748,7 +9748,7 @@ pub const esp_ble_sca_t_ESP_BLE_SCA_20PPM: esp_ble_sca_t = 7;
 pub type esp_ble_sca_t = crate::c_types::c_uint;
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Bluetooth Controller task stack size in bytes"]
     pub controller_task_stack_size: u16,
@@ -9973,7 +9973,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< Callback to notify the Host that the Controller is ready to receive the HCI data"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10042,7 +10042,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _spin_lock_create:
@@ -10110,7 +10110,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10298,7 +10298,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10317,7 +10317,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10328,7 +10328,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10365,7 +10365,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10486,7 +10486,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c2/src/include.rs
+++ b/esp-wifi-sys-esp32c2/src/include.rs
@@ -1706,7 +1706,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1715,7 +1715,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -1723,7 +1723,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -1821,7 +1821,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1831,7 +1831,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1844,7 +1844,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1852,7 +1852,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -1860,7 +1860,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -1924,7 +1924,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -1934,7 +1934,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -1942,7 +1942,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -1965,7 +1965,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3215,19 +3215,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -3968,7 +3968,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4164,7 +4164,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4173,7 +4173,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4182,7 +4182,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4191,7 +4191,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4214,7 +4214,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4275,7 +4275,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4340,7 +4340,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4692,7 +4692,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4701,7 +4701,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5143,7 +5143,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5168,7 +5168,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5397,14 +5397,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5448,7 +5448,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5465,7 +5465,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5564,7 +5564,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5585,7 +5585,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5632,7 +5632,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5739,7 +5739,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5846,7 +5846,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -5863,7 +5863,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -5874,7 +5874,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -5885,7 +5885,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6071,7 +6071,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6082,7 +6082,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6099,7 +6099,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6114,7 +6114,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6123,7 +6123,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6144,7 +6144,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6152,7 +6152,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6161,7 +6161,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6172,7 +6172,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6185,7 +6185,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6194,14 +6194,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6230,7 +6230,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6249,7 +6249,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6280,7 +6280,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6295,7 +6295,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6308,7 +6308,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6325,7 +6325,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6334,7 +6334,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6521,7 +6521,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6542,14 +6542,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6563,7 +6563,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6646,7 +6646,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6655,7 +6655,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6670,7 +6670,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6691,7 +6691,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6713,14 +6713,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 4usize],
@@ -6730,7 +6730,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -6947,7 +6947,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -6976,7 +6976,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7001,7 +7001,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7432,7 +7432,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7459,7 +7459,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7524,7 +7524,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8037,7 +8037,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8056,7 +8056,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8102,7 +8102,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8127,7 +8127,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8144,7 +8144,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8154,7 +8154,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8162,7 +8162,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8532,7 +8532,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -8925,7 +8925,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -8942,7 +8942,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9046,13 +9046,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9173,7 +9173,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9234,7 +9234,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 2;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9350,7 +9350,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9499,27 +9499,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -10141,7 +10141,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -10180,7 +10180,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Version number of the defined structure"]
     pub config_version: u32,
@@ -10317,7 +10317,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10402,7 +10402,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10463,7 +10463,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10643,7 +10643,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10662,7 +10662,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10673,7 +10673,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10710,7 +10710,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10831,7 +10831,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c2/src/include.rs
+++ b/esp-wifi-sys-esp32c2/src/include.rs
@@ -1706,7 +1706,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1715,7 +1715,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -1723,7 +1723,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -1821,7 +1821,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1831,7 +1831,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1844,7 +1844,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1852,7 +1852,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -1860,7 +1860,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -1924,7 +1924,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -1934,7 +1934,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -1942,7 +1942,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -1965,7 +1965,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3215,19 +3215,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -3968,7 +3968,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4164,7 +4164,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4173,7 +4173,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4182,7 +4182,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4191,7 +4191,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4214,7 +4214,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4275,7 +4275,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4340,7 +4340,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4571,7 +4571,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -4692,7 +4692,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4701,7 +4701,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -4710,7 +4710,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -4730,7 +4730,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -4739,7 +4739,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -4780,7 +4780,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -5143,7 +5143,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5168,7 +5168,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5397,14 +5397,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5448,7 +5448,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5465,7 +5465,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5564,7 +5564,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5585,7 +5585,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5632,7 +5632,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5739,7 +5739,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5846,7 +5846,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -5863,7 +5863,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -5874,7 +5874,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -5885,7 +5885,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6071,7 +6071,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6082,7 +6082,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6099,7 +6099,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6114,7 +6114,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6123,7 +6123,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6144,7 +6144,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6152,7 +6152,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6161,7 +6161,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6172,7 +6172,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6185,7 +6185,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6194,14 +6194,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6230,7 +6230,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6249,7 +6249,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6280,7 +6280,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6295,7 +6295,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6308,7 +6308,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6325,7 +6325,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6334,7 +6334,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6521,7 +6521,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6542,14 +6542,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6563,7 +6563,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6646,7 +6646,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6655,7 +6655,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6670,7 +6670,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6691,7 +6691,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6713,14 +6713,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 4usize],
@@ -6730,7 +6730,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -6947,7 +6947,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -6976,7 +6976,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7001,7 +7001,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7432,7 +7432,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7459,7 +7459,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7524,7 +7524,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8037,7 +8037,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8056,7 +8056,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8102,7 +8102,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8127,7 +8127,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8144,7 +8144,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8154,7 +8154,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8162,7 +8162,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8532,7 +8532,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -8925,7 +8925,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -8942,7 +8942,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9046,13 +9046,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9173,7 +9173,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9234,7 +9234,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 2;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9350,7 +9350,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9499,27 +9499,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -10141,7 +10141,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -10180,7 +10180,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Version number of the defined structure"]
     pub config_version: u32,
@@ -10317,7 +10317,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10402,7 +10402,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10463,7 +10463,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10643,7 +10643,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10662,7 +10662,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10673,7 +10673,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10710,7 +10710,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10831,7 +10831,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c3/src/include.rs
+++ b/esp-wifi-sys-esp32c3/src/include.rs
@@ -1932,7 +1932,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1941,7 +1941,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -1949,7 +1949,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -2047,7 +2047,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -2057,7 +2057,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -2070,7 +2070,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -2078,7 +2078,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2086,7 +2086,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2150,7 +2150,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2160,7 +2160,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2168,7 +2168,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2191,7 +2191,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3441,19 +3441,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4194,7 +4194,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4390,7 +4390,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4399,7 +4399,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4408,7 +4408,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4417,7 +4417,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4440,7 +4440,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4501,7 +4501,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4566,7 +4566,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4797,7 +4797,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -4918,7 +4918,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4927,7 +4927,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -4936,7 +4936,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -4956,7 +4956,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -4965,7 +4965,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -5006,7 +5006,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -5369,7 +5369,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5394,7 +5394,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5623,14 +5623,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5674,7 +5674,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5691,7 +5691,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5790,7 +5790,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5811,7 +5811,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5858,7 +5858,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5965,7 +5965,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6072,7 +6072,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6089,7 +6089,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6100,7 +6100,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6111,7 +6111,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6297,7 +6297,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6308,7 +6308,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6325,7 +6325,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6340,7 +6340,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6349,7 +6349,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6370,7 +6370,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6378,7 +6378,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6387,7 +6387,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6398,7 +6398,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6411,7 +6411,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6420,14 +6420,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6456,7 +6456,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6475,7 +6475,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6506,7 +6506,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6521,7 +6521,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6534,7 +6534,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6551,7 +6551,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6560,7 +6560,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6747,7 +6747,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6768,14 +6768,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6789,7 +6789,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6872,7 +6872,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6881,7 +6881,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6896,7 +6896,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6917,7 +6917,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6939,14 +6939,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -6956,7 +6956,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -7173,7 +7173,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7202,7 +7202,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7227,7 +7227,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7658,7 +7658,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7685,7 +7685,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7750,7 +7750,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8263,7 +8263,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8282,7 +8282,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8328,7 +8328,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8353,7 +8353,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8370,7 +8370,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8380,7 +8380,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8388,7 +8388,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8758,7 +8758,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9151,7 +9151,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9168,7 +9168,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9272,13 +9272,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9407,7 +9407,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9466,7 +9466,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9578,7 +9578,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9767,7 +9767,7 @@ pub type esp_bt_hci_tl_callback_t =
     ::core::option::Option<unsafe extern "C" fn(arg: *mut crate::c_types::c_void, status: u8)>;
 #[doc = " @brief Controller HCI transport layer function structure\n\n @note This structure must be registered when HCI transport layer is UART"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_hci_tl_t {
     #[doc = "< Magic number"]
     pub _magic: u32,
@@ -9806,7 +9806,7 @@ pub struct esp_bt_hci_tl_t {
 }
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Magic number"]
     pub magic: u32,
@@ -10079,7 +10079,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the Host can send the HCI data to Controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10147,7 +10147,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10207,7 +10207,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10387,7 +10387,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10406,7 +10406,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10417,7 +10417,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10454,7 +10454,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10575,7 +10575,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c3/src/include.rs
+++ b/esp-wifi-sys-esp32c3/src/include.rs
@@ -1932,7 +1932,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1941,7 +1941,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -1949,7 +1949,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -2047,7 +2047,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -2057,7 +2057,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -2070,7 +2070,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -2078,7 +2078,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2086,7 +2086,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2150,7 +2150,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2160,7 +2160,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2168,7 +2168,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2191,7 +2191,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3441,19 +3441,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4194,7 +4194,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4390,7 +4390,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4399,7 +4399,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4408,7 +4408,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4417,7 +4417,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4440,7 +4440,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4501,7 +4501,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4566,7 +4566,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4918,7 +4918,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4927,7 +4927,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5369,7 +5369,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5394,7 +5394,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5623,14 +5623,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5674,7 +5674,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5691,7 +5691,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5790,7 +5790,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5811,7 +5811,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5858,7 +5858,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5965,7 +5965,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6072,7 +6072,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6089,7 +6089,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6100,7 +6100,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6111,7 +6111,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6297,7 +6297,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6308,7 +6308,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6325,7 +6325,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6340,7 +6340,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6349,7 +6349,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6370,7 +6370,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6378,7 +6378,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6387,7 +6387,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6398,7 +6398,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6411,7 +6411,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6420,14 +6420,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6456,7 +6456,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6475,7 +6475,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6506,7 +6506,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6521,7 +6521,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6534,7 +6534,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6551,7 +6551,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6560,7 +6560,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6747,7 +6747,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6768,14 +6768,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6789,7 +6789,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6872,7 +6872,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6881,7 +6881,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6896,7 +6896,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6917,7 +6917,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6939,14 +6939,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -6956,7 +6956,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -7173,7 +7173,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7202,7 +7202,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7227,7 +7227,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7658,7 +7658,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7685,7 +7685,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7750,7 +7750,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8263,7 +8263,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8282,7 +8282,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8328,7 +8328,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8353,7 +8353,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8370,7 +8370,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8380,7 +8380,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8388,7 +8388,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8758,7 +8758,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9151,7 +9151,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9168,7 +9168,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9272,13 +9272,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9407,7 +9407,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9466,7 +9466,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9578,7 +9578,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9767,7 +9767,7 @@ pub type esp_bt_hci_tl_callback_t =
     ::core::option::Option<unsafe extern "C" fn(arg: *mut crate::c_types::c_void, status: u8)>;
 #[doc = " @brief Controller HCI transport layer function structure\n\n @note This structure must be registered when HCI transport layer is UART"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_hci_tl_t {
     #[doc = "< Magic number"]
     pub _magic: u32,
@@ -9806,7 +9806,7 @@ pub struct esp_bt_hci_tl_t {
 }
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Magic number"]
     pub magic: u32,
@@ -10079,7 +10079,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the Host can send the HCI data to Controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10147,7 +10147,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10207,7 +10207,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10387,7 +10387,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10406,7 +10406,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10417,7 +10417,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10454,7 +10454,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10575,7 +10575,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c5/src/include.rs
+++ b/esp-wifi-sys-esp32c5/src/include.rs
@@ -3439,7 +3439,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3448,7 +3448,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3456,7 +3456,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3554,7 +3554,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3564,7 +3564,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3577,7 +3577,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3585,7 +3585,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3593,7 +3593,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3657,7 +3657,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3667,7 +3667,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3675,7 +3675,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3698,7 +3698,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4948,19 +4948,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5701,7 +5701,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5899,7 +5899,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5908,7 +5908,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5917,7 +5917,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5926,7 +5926,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5949,7 +5949,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -6010,7 +6010,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -6075,7 +6075,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6306,7 +6306,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -6427,7 +6427,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6436,7 +6436,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6445,7 +6445,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -6465,7 +6465,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -6474,7 +6474,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -6515,7 +6515,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -6878,7 +6878,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6903,7 +6903,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -7132,14 +7132,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7183,7 +7183,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7200,7 +7200,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7299,7 +7299,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7320,7 +7320,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7367,7 +7367,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7474,7 +7474,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7581,7 +7581,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7598,7 +7598,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7609,7 +7609,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7620,7 +7620,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7814,7 +7814,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7825,7 +7825,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7842,7 +7842,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7857,7 +7857,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7866,7 +7866,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7887,7 +7887,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7895,7 +7895,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7904,7 +7904,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7915,7 +7915,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7928,7 +7928,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7937,14 +7937,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7973,7 +7973,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7992,7 +7992,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -8023,7 +8023,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -8038,7 +8038,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -8051,7 +8051,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -8068,7 +8068,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -8077,7 +8077,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8264,7 +8264,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8285,14 +8285,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8306,7 +8306,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8389,7 +8389,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8398,7 +8398,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8413,7 +8413,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8434,7 +8434,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8456,7 +8456,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8483,7 +8483,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8742,7 +8742,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8936,7 +8936,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8947,7 +8947,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -9101,7 +9101,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9388,7 +9388,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9407,7 +9407,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9416,7 +9416,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9447,7 +9447,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9466,7 +9466,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9475,7 +9475,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9494,7 +9494,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9503,7 +9503,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9512,7 +9512,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9672,7 +9672,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9691,7 +9691,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9716,7 +9716,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -10147,7 +10147,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -10174,7 +10174,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -10239,7 +10239,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10752,7 +10752,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10771,7 +10771,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10817,7 +10817,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10842,7 +10842,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10859,7 +10859,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10869,7 +10869,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10877,7 +10877,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -11247,7 +11247,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11646,7 +11646,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 256usize],
@@ -11663,7 +11663,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11767,13 +11767,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11909,7 +11909,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11968,7 +11968,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -12080,7 +12080,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -12229,27 +12229,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12977,7 +12977,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13142,7 +13142,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13192,7 +13192,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13341,7 +13341,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13474,7 +13474,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13577,7 +13577,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13859,7 +13859,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14072,7 +14072,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14328,7 +14328,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14445,7 +14445,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14658,7 +14658,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14708,7 +14708,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14775,7 +14775,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14876,7 +14876,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14926,7 +14926,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14976,7 +14976,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15045,7 +15045,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15146,7 +15146,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15257,7 +15257,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15526,7 +15526,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15629,7 +15629,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15683,7 +15683,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15737,7 +15737,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15791,7 +15791,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15862,7 +15862,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15967,7 +15967,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16048,7 +16048,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16133,7 +16133,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16218,7 +16218,7 @@ pub union pmu_power_wait_timer2_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer2_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16303,7 +16303,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16468,7 +16468,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16569,7 +16569,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16702,7 +16702,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16772,7 +16772,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16857,7 +16857,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16924,7 +16924,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16974,7 +16974,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17027,7 +17027,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17112,7 +17112,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17165,7 +17165,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17234,7 +17234,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17303,7 +17303,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17370,7 +17370,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17423,7 +17423,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17492,7 +17492,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17542,7 +17542,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17723,7 +17723,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17776,7 +17776,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17906,7 +17906,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18145,7 +18145,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18326,7 +18326,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18425,7 +18425,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18494,7 +18494,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18547,7 +18547,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18632,7 +18632,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18717,7 +18717,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19026,7 +19026,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19080,7 +19080,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19504,7 +19504,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19658,7 +19658,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19817,7 +19817,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19944,7 +19944,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19996,7 +19996,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20059,7 +20059,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20154,7 +20154,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20197,7 +20197,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -20205,7 +20205,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20300,7 +20300,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20507,7 +20507,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20550,7 +20550,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20558,7 +20558,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20653,7 +20653,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20748,7 +20748,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20791,7 +20791,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20806,7 +20806,7 @@ pub struct pmu_hp_param_t {
     pub reset_wait_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20854,18 +20854,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20885,13 +20885,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20906,7 +20906,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20932,7 +20932,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -21051,7 +21051,7 @@ pub union _bindgen_ty_2__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21234,7 +21234,7 @@ pub union _bindgen_ty_2__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21544,7 +21544,7 @@ pub union _bindgen_ty_2__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21885,7 +21885,7 @@ pub union _bindgen_ty_2__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22019,7 +22019,7 @@ pub union _bindgen_ty_2__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22520,7 +22520,7 @@ pub union _bindgen_ty_2__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22941,7 +22941,7 @@ pub union _bindgen_ty_2__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_2__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23019,7 +23019,7 @@ pub union _bindgen_ty_3__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23088,7 +23088,7 @@ pub union _bindgen_ty_3__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23209,7 +23209,7 @@ pub union _bindgen_ty_3__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23329,7 +23329,7 @@ pub union _bindgen_ty_3__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23451,7 +23451,7 @@ pub union _bindgen_ty_3__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23520,7 +23520,7 @@ pub union _bindgen_ty_3__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23573,7 +23573,7 @@ pub union _bindgen_ty_3__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24106,7 +24106,7 @@ pub union _bindgen_ty_3__bindgen_ty_8 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24639,7 +24639,7 @@ pub union _bindgen_ty_3__bindgen_ty_9 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_9__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24740,7 +24740,7 @@ pub union _bindgen_ty_3__bindgen_ty_10 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_10__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25273,7 +25273,7 @@ pub union _bindgen_ty_3__bindgen_ty_11 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_11__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25327,7 +25327,7 @@ pub union _bindgen_ty_3__bindgen_ty_12 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_12__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25668,7 +25668,7 @@ pub union _bindgen_ty_3__bindgen_ty_13 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_13__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25753,7 +25753,7 @@ pub union _bindgen_ty_3__bindgen_ty_14 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _bindgen_ty_3__bindgen_ty_14__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25800,7 +25800,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -26024,7 +26024,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -26059,7 +26059,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -26212,7 +26212,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -26301,7 +26301,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -26361,7 +26361,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -26542,7 +26542,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -26584,7 +26584,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -26603,7 +26603,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -26614,7 +26614,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -26651,7 +26651,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -26772,7 +26772,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c5/src/include.rs
+++ b/esp-wifi-sys-esp32c5/src/include.rs
@@ -3439,7 +3439,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3448,7 +3448,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3456,7 +3456,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3554,7 +3554,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3564,7 +3564,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3577,7 +3577,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3585,7 +3585,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3593,7 +3593,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3657,7 +3657,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3667,7 +3667,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3675,7 +3675,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3698,7 +3698,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4948,19 +4948,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5701,7 +5701,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5899,7 +5899,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5908,7 +5908,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5917,7 +5917,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5926,7 +5926,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5949,7 +5949,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -6010,7 +6010,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -6075,7 +6075,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6427,7 +6427,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6436,7 +6436,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6878,7 +6878,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6903,7 +6903,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -7132,14 +7132,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7183,7 +7183,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7200,7 +7200,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7299,7 +7299,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7320,7 +7320,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7367,7 +7367,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7474,7 +7474,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7581,7 +7581,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7598,7 +7598,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7609,7 +7609,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7620,7 +7620,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7814,7 +7814,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7825,7 +7825,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7842,7 +7842,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7857,7 +7857,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7866,7 +7866,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7887,7 +7887,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7895,7 +7895,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7904,7 +7904,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7915,7 +7915,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7928,7 +7928,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7937,14 +7937,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7973,7 +7973,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7992,7 +7992,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -8023,7 +8023,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -8038,7 +8038,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -8051,7 +8051,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -8068,7 +8068,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -8077,7 +8077,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8264,7 +8264,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8285,14 +8285,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8306,7 +8306,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8389,7 +8389,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8398,7 +8398,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8413,7 +8413,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8434,7 +8434,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8456,7 +8456,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8483,7 +8483,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8742,7 +8742,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8936,7 +8936,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8947,7 +8947,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -9101,7 +9101,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9388,7 +9388,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9407,7 +9407,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9416,7 +9416,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9447,7 +9447,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9466,7 +9466,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9475,7 +9475,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9494,7 +9494,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9503,7 +9503,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9512,7 +9512,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9672,7 +9672,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9691,7 +9691,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9716,7 +9716,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -10147,7 +10147,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -10174,7 +10174,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -10239,7 +10239,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10752,7 +10752,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10771,7 +10771,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10817,7 +10817,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10842,7 +10842,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10859,7 +10859,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10869,7 +10869,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10877,7 +10877,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -11247,7 +11247,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11646,7 +11646,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 256usize],
@@ -11663,7 +11663,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11767,13 +11767,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11909,7 +11909,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11968,7 +11968,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -12080,7 +12080,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -12229,27 +12229,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12977,7 +12977,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13142,7 +13142,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13192,7 +13192,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13341,7 +13341,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13474,7 +13474,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13577,7 +13577,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13859,7 +13859,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14072,7 +14072,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14328,7 +14328,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14445,7 +14445,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14658,7 +14658,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14708,7 +14708,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14775,7 +14775,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14876,7 +14876,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14926,7 +14926,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14976,7 +14976,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15045,7 +15045,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15146,7 +15146,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15257,7 +15257,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15526,7 +15526,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15629,7 +15629,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15683,7 +15683,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15737,7 +15737,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15791,7 +15791,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15862,7 +15862,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15967,7 +15967,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16048,7 +16048,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16133,7 +16133,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16218,7 +16218,7 @@ pub union pmu_power_wait_timer2_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer2_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16303,7 +16303,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16468,7 +16468,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16569,7 +16569,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16702,7 +16702,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16772,7 +16772,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16857,7 +16857,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16924,7 +16924,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16974,7 +16974,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17027,7 +17027,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17112,7 +17112,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17165,7 +17165,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17234,7 +17234,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17303,7 +17303,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17370,7 +17370,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17423,7 +17423,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17492,7 +17492,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17542,7 +17542,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17723,7 +17723,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17776,7 +17776,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17906,7 +17906,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18145,7 +18145,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18326,7 +18326,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18425,7 +18425,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18494,7 +18494,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18547,7 +18547,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18632,7 +18632,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18717,7 +18717,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19026,7 +19026,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19080,7 +19080,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19504,7 +19504,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19658,7 +19658,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19817,7 +19817,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19944,7 +19944,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19996,7 +19996,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20059,7 +20059,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20154,7 +20154,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20197,7 +20197,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -20205,7 +20205,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20300,7 +20300,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20507,7 +20507,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20550,7 +20550,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20558,7 +20558,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20653,7 +20653,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20748,7 +20748,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20791,7 +20791,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20806,7 +20806,7 @@ pub struct pmu_hp_param_t {
     pub reset_wait_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20854,18 +20854,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20885,13 +20885,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20906,7 +20906,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20932,7 +20932,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -21051,7 +21051,7 @@ pub union _bindgen_ty_2__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21234,7 +21234,7 @@ pub union _bindgen_ty_2__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21544,7 +21544,7 @@ pub union _bindgen_ty_2__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21885,7 +21885,7 @@ pub union _bindgen_ty_2__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22019,7 +22019,7 @@ pub union _bindgen_ty_2__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22520,7 +22520,7 @@ pub union _bindgen_ty_2__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22941,7 +22941,7 @@ pub union _bindgen_ty_2__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_2__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23019,7 +23019,7 @@ pub union _bindgen_ty_3__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23088,7 +23088,7 @@ pub union _bindgen_ty_3__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23209,7 +23209,7 @@ pub union _bindgen_ty_3__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23329,7 +23329,7 @@ pub union _bindgen_ty_3__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23451,7 +23451,7 @@ pub union _bindgen_ty_3__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23520,7 +23520,7 @@ pub union _bindgen_ty_3__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23573,7 +23573,7 @@ pub union _bindgen_ty_3__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24106,7 +24106,7 @@ pub union _bindgen_ty_3__bindgen_ty_8 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_8__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24639,7 +24639,7 @@ pub union _bindgen_ty_3__bindgen_ty_9 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_9__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24740,7 +24740,7 @@ pub union _bindgen_ty_3__bindgen_ty_10 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_10__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25273,7 +25273,7 @@ pub union _bindgen_ty_3__bindgen_ty_11 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_11__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25327,7 +25327,7 @@ pub union _bindgen_ty_3__bindgen_ty_12 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_12__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25668,7 +25668,7 @@ pub union _bindgen_ty_3__bindgen_ty_13 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_13__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25753,7 +25753,7 @@ pub union _bindgen_ty_3__bindgen_ty_14 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _bindgen_ty_3__bindgen_ty_14__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -25800,7 +25800,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -26024,7 +26024,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -26059,7 +26059,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -26212,7 +26212,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -26301,7 +26301,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -26361,7 +26361,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -26542,7 +26542,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -26584,7 +26584,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -26603,7 +26603,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -26614,7 +26614,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -26651,7 +26651,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -26772,7 +26772,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c6/src/include.rs
+++ b/esp-wifi-sys-esp32c6/src/include.rs
@@ -3263,7 +3263,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3272,7 +3272,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3280,7 +3280,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3378,7 +3378,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3388,7 +3388,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3401,7 +3401,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3409,7 +3409,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3417,7 +3417,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3481,7 +3481,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3491,7 +3491,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3499,7 +3499,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3522,7 +3522,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4772,19 +4772,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5525,7 +5525,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5721,7 +5721,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5730,7 +5730,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5739,7 +5739,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5748,7 +5748,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5771,7 +5771,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5832,7 +5832,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5897,7 +5897,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6128,7 +6128,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -6249,7 +6249,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6258,7 +6258,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6267,7 +6267,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -6287,7 +6287,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -6296,7 +6296,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -6337,7 +6337,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -6700,7 +6700,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6725,7 +6725,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -6954,14 +6954,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7005,7 +7005,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7022,7 +7022,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7121,7 +7121,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7142,7 +7142,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7189,7 +7189,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7296,7 +7296,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7403,7 +7403,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7420,7 +7420,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7431,7 +7431,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7442,7 +7442,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7636,7 +7636,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7647,7 +7647,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7664,7 +7664,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7679,7 +7679,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7688,7 +7688,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7709,7 +7709,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7717,7 +7717,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7726,7 +7726,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7737,7 +7737,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7750,7 +7750,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7759,14 +7759,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7795,7 +7795,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7814,7 +7814,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7845,7 +7845,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7860,7 +7860,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7873,7 +7873,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7890,7 +7890,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -7899,7 +7899,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8086,7 +8086,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8107,14 +8107,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8128,7 +8128,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8211,7 +8211,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8220,7 +8220,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8235,7 +8235,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8256,7 +8256,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8278,7 +8278,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8305,7 +8305,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8514,7 +8514,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8708,7 +8708,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8719,7 +8719,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8873,7 +8873,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9171,7 +9171,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9190,7 +9190,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9199,7 +9199,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9230,7 +9230,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9249,7 +9249,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9258,7 +9258,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9277,7 +9277,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9286,7 +9286,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9295,7 +9295,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9455,7 +9455,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9474,7 +9474,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9499,7 +9499,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9930,7 +9930,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9957,7 +9957,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -10022,7 +10022,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10535,7 +10535,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10554,7 +10554,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10600,7 +10600,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10625,7 +10625,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10642,7 +10642,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10652,7 +10652,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10660,7 +10660,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -11030,7 +11030,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11429,7 +11429,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -11446,7 +11446,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11550,13 +11550,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11692,7 +11692,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11751,7 +11751,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11863,7 +11863,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -12012,27 +12012,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12692,7 +12692,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12857,7 +12857,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12907,7 +12907,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13056,7 +13056,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13189,7 +13189,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13292,7 +13292,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13590,7 +13590,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13803,7 +13803,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14091,7 +14091,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14208,7 +14208,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14405,7 +14405,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14455,7 +14455,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14522,7 +14522,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14623,7 +14623,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14673,7 +14673,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14723,7 +14723,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14792,7 +14792,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14893,7 +14893,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15004,7 +15004,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15273,7 +15273,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15376,7 +15376,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15430,7 +15430,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15484,7 +15484,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15538,7 +15538,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15609,7 +15609,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15714,7 +15714,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15795,7 +15795,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15880,7 +15880,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15965,7 +15965,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16130,7 +16130,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16231,7 +16231,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16364,7 +16364,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16434,7 +16434,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16519,7 +16519,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16585,7 +16585,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16635,7 +16635,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16688,7 +16688,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16773,7 +16773,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16826,7 +16826,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16895,7 +16895,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16964,7 +16964,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17031,7 +17031,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17084,7 +17084,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17153,7 +17153,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17203,7 +17203,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17336,7 +17336,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17389,7 +17389,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17519,7 +17519,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17758,7 +17758,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17939,7 +17939,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18039,7 +18039,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18108,7 +18108,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18161,7 +18161,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18246,7 +18246,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18331,7 +18331,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18640,7 +18640,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18694,7 +18694,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19118,7 +19118,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19258,7 +19258,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19417,7 +19417,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19544,7 +19544,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19596,7 +19596,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19659,7 +19659,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19754,7 +19754,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19797,7 +19797,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19805,7 +19805,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19900,7 +19900,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20027,7 +20027,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20070,7 +20070,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20078,7 +20078,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20173,7 +20173,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20268,7 +20268,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20311,7 +20311,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20324,7 +20324,7 @@ pub struct pmu_hp_param_t {
     pub min_slp_slow_clk_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20370,18 +20370,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20401,13 +20401,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20421,7 +20421,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20445,7 +20445,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -20549,7 +20549,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20599,7 +20599,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20812,7 +20812,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21009,7 +21009,7 @@ pub union modem_syscon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21143,7 +21143,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21500,7 +21500,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21924,7 +21924,7 @@ pub union modem_syscon_clk_conf1_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf1_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22348,7 +22348,7 @@ pub union modem_syscon_wifi_bb_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_wifi_bb_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22383,7 +22383,7 @@ pub union modem_syscon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22468,7 +22468,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22535,7 +22535,7 @@ pub union modem_lpcon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22604,7 +22604,7 @@ pub union modem_lpcon_lp_timer_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_lp_timer_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22725,7 +22725,7 @@ pub union modem_lpcon_coex_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_coex_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22845,7 +22845,7 @@ pub union modem_lpcon_wifi_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_wifi_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22967,7 +22967,7 @@ pub union modem_lpcon_i2c_mst_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_i2c_mst_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23020,7 +23020,7 @@ pub union modem_lpcon_modem_32k_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_modem_32k_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23073,7 +23073,7 @@ pub union modem_lpcon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23174,7 +23174,7 @@ pub union modem_lpcon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23371,7 +23371,7 @@ pub union modem_lpcon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23472,7 +23472,7 @@ pub union modem_lpcon_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23573,7 +23573,7 @@ pub union modem_lpcon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23852,7 +23852,7 @@ pub union modem_lpcon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23914,7 +23914,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -24146,7 +24146,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -24181,7 +24181,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -24336,7 +24336,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24425,7 +24425,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24485,7 +24485,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -24666,7 +24666,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -24708,7 +24708,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -24727,7 +24727,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -24738,7 +24738,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -24775,7 +24775,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -24896,7 +24896,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c6/src/include.rs
+++ b/esp-wifi-sys-esp32c6/src/include.rs
@@ -3263,7 +3263,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3272,7 +3272,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3280,7 +3280,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3378,7 +3378,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3388,7 +3388,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3401,7 +3401,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3409,7 +3409,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3417,7 +3417,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3481,7 +3481,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3491,7 +3491,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3499,7 +3499,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3522,7 +3522,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4772,19 +4772,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5525,7 +5525,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5721,7 +5721,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5730,7 +5730,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5739,7 +5739,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5748,7 +5748,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5771,7 +5771,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5832,7 +5832,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5897,7 +5897,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6249,7 +6249,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6258,7 +6258,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6700,7 +6700,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6725,7 +6725,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -6954,14 +6954,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7005,7 +7005,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7022,7 +7022,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7121,7 +7121,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7142,7 +7142,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7189,7 +7189,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7296,7 +7296,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7403,7 +7403,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7420,7 +7420,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7431,7 +7431,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7442,7 +7442,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7636,7 +7636,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7647,7 +7647,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7664,7 +7664,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7679,7 +7679,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7688,7 +7688,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7709,7 +7709,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7717,7 +7717,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7726,7 +7726,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7737,7 +7737,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7750,7 +7750,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7759,14 +7759,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7795,7 +7795,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7814,7 +7814,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7845,7 +7845,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7860,7 +7860,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7873,7 +7873,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7890,7 +7890,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -7899,7 +7899,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8086,7 +8086,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8107,14 +8107,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8128,7 +8128,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8211,7 +8211,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8220,7 +8220,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8235,7 +8235,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8256,7 +8256,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8278,7 +8278,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8305,7 +8305,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8514,7 +8514,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8708,7 +8708,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8719,7 +8719,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8873,7 +8873,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9171,7 +9171,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9190,7 +9190,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9199,7 +9199,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9230,7 +9230,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9249,7 +9249,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9258,7 +9258,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9277,7 +9277,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9286,7 +9286,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9295,7 +9295,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9455,7 +9455,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9474,7 +9474,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9499,7 +9499,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9930,7 +9930,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9957,7 +9957,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -10022,7 +10022,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10535,7 +10535,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10554,7 +10554,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10600,7 +10600,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10625,7 +10625,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10642,7 +10642,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10652,7 +10652,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10660,7 +10660,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -11030,7 +11030,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11429,7 +11429,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -11446,7 +11446,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11550,13 +11550,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11692,7 +11692,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11751,7 +11751,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11863,7 +11863,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -12012,27 +12012,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12692,7 +12692,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12857,7 +12857,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12907,7 +12907,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13056,7 +13056,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13189,7 +13189,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13292,7 +13292,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13590,7 +13590,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13803,7 +13803,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14091,7 +14091,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14208,7 +14208,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14405,7 +14405,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14455,7 +14455,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14522,7 +14522,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14623,7 +14623,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14673,7 +14673,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14723,7 +14723,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14792,7 +14792,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14893,7 +14893,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15004,7 +15004,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15273,7 +15273,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15376,7 +15376,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15430,7 +15430,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15484,7 +15484,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15538,7 +15538,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15609,7 +15609,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15714,7 +15714,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15795,7 +15795,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15880,7 +15880,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15965,7 +15965,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16130,7 +16130,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16231,7 +16231,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16364,7 +16364,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16434,7 +16434,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16519,7 +16519,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16585,7 +16585,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16635,7 +16635,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16688,7 +16688,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16773,7 +16773,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16826,7 +16826,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16895,7 +16895,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16964,7 +16964,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17031,7 +17031,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17084,7 +17084,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17153,7 +17153,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17203,7 +17203,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17336,7 +17336,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17389,7 +17389,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17519,7 +17519,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17758,7 +17758,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17939,7 +17939,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18039,7 +18039,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18108,7 +18108,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18161,7 +18161,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18246,7 +18246,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18331,7 +18331,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18640,7 +18640,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18694,7 +18694,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19118,7 +19118,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19258,7 +19258,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19417,7 +19417,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19544,7 +19544,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19596,7 +19596,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19659,7 +19659,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19754,7 +19754,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19797,7 +19797,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19805,7 +19805,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19900,7 +19900,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20027,7 +20027,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20070,7 +20070,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20078,7 +20078,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20173,7 +20173,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20268,7 +20268,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20311,7 +20311,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20324,7 +20324,7 @@ pub struct pmu_hp_param_t {
     pub min_slp_slow_clk_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20370,18 +20370,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20401,13 +20401,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20421,7 +20421,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20445,7 +20445,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -20549,7 +20549,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20599,7 +20599,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20812,7 +20812,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21009,7 +21009,7 @@ pub union modem_syscon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21143,7 +21143,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21500,7 +21500,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21924,7 +21924,7 @@ pub union modem_syscon_clk_conf1_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf1_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22348,7 +22348,7 @@ pub union modem_syscon_wifi_bb_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_wifi_bb_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22383,7 +22383,7 @@ pub union modem_syscon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22468,7 +22468,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22535,7 +22535,7 @@ pub union modem_lpcon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22604,7 +22604,7 @@ pub union modem_lpcon_lp_timer_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_lp_timer_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22725,7 +22725,7 @@ pub union modem_lpcon_coex_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_coex_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22845,7 +22845,7 @@ pub union modem_lpcon_wifi_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_wifi_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22967,7 +22967,7 @@ pub union modem_lpcon_i2c_mst_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_i2c_mst_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23020,7 +23020,7 @@ pub union modem_lpcon_modem_32k_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_modem_32k_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23073,7 +23073,7 @@ pub union modem_lpcon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23174,7 +23174,7 @@ pub union modem_lpcon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23371,7 +23371,7 @@ pub union modem_lpcon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23472,7 +23472,7 @@ pub union modem_lpcon_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23573,7 +23573,7 @@ pub union modem_lpcon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23852,7 +23852,7 @@ pub union modem_lpcon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23914,7 +23914,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -24146,7 +24146,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -24181,7 +24181,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -24336,7 +24336,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24425,7 +24425,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24485,7 +24485,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -24666,7 +24666,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -24708,7 +24708,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -24727,7 +24727,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -24738,7 +24738,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -24775,7 +24775,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -24896,7 +24896,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c61/src/include.rs
+++ b/esp-wifi-sys-esp32c61/src/include.rs
@@ -3085,7 +3085,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3094,7 +3094,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3102,7 +3102,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3200,7 +3200,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3210,7 +3210,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3223,7 +3223,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3231,7 +3231,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3239,7 +3239,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3303,7 +3303,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3313,7 +3313,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3321,7 +3321,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3344,7 +3344,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4594,19 +4594,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5347,7 +5347,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5543,7 +5543,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5552,7 +5552,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5561,7 +5561,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5570,7 +5570,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5593,7 +5593,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5654,7 +5654,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5719,7 +5719,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6071,7 +6071,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6080,7 +6080,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6522,7 +6522,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6547,7 +6547,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -6776,14 +6776,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -6827,7 +6827,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -6844,7 +6844,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -6943,7 +6943,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6964,7 +6964,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7011,7 +7011,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7118,7 +7118,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7225,7 +7225,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7242,7 +7242,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7253,7 +7253,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7264,7 +7264,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7458,7 +7458,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7469,7 +7469,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7486,7 +7486,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7501,7 +7501,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7510,7 +7510,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7531,7 +7531,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7539,7 +7539,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7548,7 +7548,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7559,7 +7559,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7572,7 +7572,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7581,14 +7581,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7617,7 +7617,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7636,7 +7636,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7667,7 +7667,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7682,7 +7682,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7695,7 +7695,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7712,7 +7712,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -7721,7 +7721,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -7908,7 +7908,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -7929,14 +7929,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -7950,7 +7950,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8033,7 +8033,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8042,7 +8042,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8057,7 +8057,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8078,7 +8078,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8100,7 +8100,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8127,7 +8127,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8386,7 +8386,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8580,7 +8580,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8591,7 +8591,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8745,7 +8745,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9032,7 +9032,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9051,7 +9051,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9060,7 +9060,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9091,7 +9091,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9110,7 +9110,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9119,7 +9119,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9138,7 +9138,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9147,7 +9147,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9156,7 +9156,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9316,7 +9316,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9335,7 +9335,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9360,7 +9360,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9791,7 +9791,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9818,7 +9818,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -9883,7 +9883,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10396,7 +10396,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10415,7 +10415,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10461,7 +10461,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10486,7 +10486,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10503,7 +10503,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10513,7 +10513,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10521,7 +10521,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -10891,7 +10891,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11290,7 +11290,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -11307,7 +11307,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11411,13 +11411,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11553,7 +11553,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11612,7 +11612,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11724,7 +11724,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -11873,27 +11873,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12409,7 +12409,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12574,7 +12574,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12624,7 +12624,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12773,7 +12773,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12906,7 +12906,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13009,7 +13009,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13307,7 +13307,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13520,7 +13520,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13808,7 +13808,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13928,7 +13928,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14119,7 +14119,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14215,7 +14215,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14278,7 +14278,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_4 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14347,7 +14347,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14397,7 +14397,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14464,7 +14464,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14565,7 +14565,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14615,7 +14615,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14665,7 +14665,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14734,7 +14734,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14835,7 +14835,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14946,7 +14946,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15215,7 +15215,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15318,7 +15318,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15372,7 +15372,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15426,7 +15426,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15480,7 +15480,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15551,7 +15551,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15656,7 +15656,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15737,7 +15737,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15822,7 +15822,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15907,7 +15907,7 @@ pub union pmu_power_wait_timer2_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer2_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15992,7 +15992,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16157,7 +16157,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16258,7 +16258,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16391,7 +16391,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16461,7 +16461,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16546,7 +16546,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16613,7 +16613,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16663,7 +16663,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16716,7 +16716,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16801,7 +16801,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16854,7 +16854,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16923,7 +16923,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16992,7 +16992,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17059,7 +17059,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17112,7 +17112,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17181,7 +17181,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17231,7 +17231,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17396,7 +17396,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17449,7 +17449,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17579,7 +17579,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17818,7 +17818,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17999,7 +17999,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18098,7 +18098,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18167,7 +18167,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18220,7 +18220,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18305,7 +18305,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18390,7 +18390,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18699,7 +18699,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18753,7 +18753,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19177,7 +19177,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19331,7 +19331,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19490,7 +19490,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19617,7 +19617,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19669,7 +19669,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19732,7 +19732,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19827,7 +19827,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19870,7 +19870,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19878,7 +19878,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19973,7 +19973,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20100,7 +20100,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20143,7 +20143,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20151,7 +20151,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20246,7 +20246,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20341,7 +20341,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20384,7 +20384,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20399,7 +20399,7 @@ pub struct pmu_hp_param_t {
     pub reset_wait_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20447,18 +20447,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20478,13 +20478,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20499,7 +20499,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20525,7 +20525,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -20630,7 +20630,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20830,7 +20830,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21140,7 +21140,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21401,7 +21401,7 @@ pub union modem_syscon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21535,7 +21535,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21924,7 +21924,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22313,7 +22313,7 @@ pub union modem_syscon_wifi_bb_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_wifi_bb_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22348,7 +22348,7 @@ pub union modem_syscon_fe_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_fe_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22383,7 +22383,7 @@ pub union modem_syscon_mem_rf1_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_mem_rf1_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22419,7 +22419,7 @@ pub union modem_syscon_mem_rf2_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_mem_rf2_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22455,7 +22455,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22524,7 +22524,7 @@ pub union modem_lpcon_test_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_test_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22574,7 +22574,7 @@ pub union modem_lpcon_lp_timer_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_lp_timer_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22695,7 +22695,7 @@ pub union modem_lpcon_coex_lp_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_coex_lp_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22815,7 +22815,7 @@ pub union modem_lpcon_wifi_lp_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_wifi_lp_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22937,7 +22937,7 @@ pub union modem_lpcon_modem_src_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_modem_src_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23006,7 +23006,7 @@ pub union modem_lpcon_modem_32k_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_modem_32k_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23059,7 +23059,7 @@ pub union modem_lpcon_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23160,7 +23160,7 @@ pub union modem_lpcon_clk_conf_force_on_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_force_on_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23277,7 +23277,7 @@ pub union modem_lpcon_clk_conf_power_st_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_power_st_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23378,7 +23378,7 @@ pub union modem_lpcon_rst_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_rst_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23495,7 +23495,7 @@ pub union modem_lpcon_tick_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_tick_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23549,7 +23549,7 @@ pub union modem_lpcon_mem_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_mem_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23778,7 +23778,7 @@ pub union modem_lpcon_mem_rf1_aux_ctrl_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_mem_rf1_aux_ctrl_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23814,7 +23814,7 @@ pub union modem_lpcon_mem_rf2_aux_ctrl_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_mem_rf2_aux_ctrl_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23850,7 +23850,7 @@ pub union modem_lpcon_apb_mem_sel_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_apb_mem_sel_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23935,7 +23935,7 @@ pub union modem_lpcon_dcmem_valid_0_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_dcmem_valid_0_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23970,7 +23970,7 @@ pub union modem_lpcon_dcmem_valid_1_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_dcmem_valid_1_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24005,7 +24005,7 @@ pub union modem_lpcon_dcmem_valid_2_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_dcmem_valid_2_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24040,7 +24040,7 @@ pub union modem_lpcon_dcmem_valid_3_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_dcmem_valid_3_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24075,7 +24075,7 @@ pub union modem_lpcon_date_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_date_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24145,7 +24145,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -24363,7 +24363,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -24398,7 +24398,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -24551,7 +24551,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24636,7 +24636,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24696,7 +24696,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -24876,7 +24876,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -24895,7 +24895,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -24906,7 +24906,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -24943,7 +24943,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -25064,7 +25064,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32c61/src/include.rs
+++ b/esp-wifi-sys-esp32c61/src/include.rs
@@ -3085,7 +3085,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3094,7 +3094,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3102,7 +3102,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3200,7 +3200,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3210,7 +3210,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3223,7 +3223,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3231,7 +3231,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3239,7 +3239,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3303,7 +3303,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3313,7 +3313,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3321,7 +3321,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3344,7 +3344,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4594,19 +4594,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5347,7 +5347,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5543,7 +5543,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5552,7 +5552,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5561,7 +5561,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5570,7 +5570,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5593,7 +5593,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5654,7 +5654,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5719,7 +5719,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -5950,7 +5950,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -6071,7 +6071,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6080,7 +6080,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6089,7 +6089,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -6109,7 +6109,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -6118,7 +6118,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -6159,7 +6159,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -6522,7 +6522,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6547,7 +6547,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -6776,14 +6776,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -6827,7 +6827,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -6844,7 +6844,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -6943,7 +6943,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6964,7 +6964,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7011,7 +7011,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7118,7 +7118,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7225,7 +7225,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7242,7 +7242,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7253,7 +7253,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7264,7 +7264,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7458,7 +7458,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7469,7 +7469,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7486,7 +7486,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7501,7 +7501,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7510,7 +7510,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7531,7 +7531,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7539,7 +7539,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7548,7 +7548,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7559,7 +7559,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7572,7 +7572,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7581,14 +7581,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7617,7 +7617,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7636,7 +7636,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7667,7 +7667,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7682,7 +7682,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7695,7 +7695,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7712,7 +7712,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -7721,7 +7721,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -7908,7 +7908,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -7929,14 +7929,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -7950,7 +7950,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8033,7 +8033,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8042,7 +8042,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8057,7 +8057,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8078,7 +8078,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8100,7 +8100,7 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
@@ -8127,7 +8127,7 @@ pub const ESP_CSI_ACQUIRE_STBC_SAMPLE_HELTFS: _bindgen_ty_1 = 2;
 pub type _bindgen_ty_1 = crate::c_types::c_uint;
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_acquire_config_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8386,7 +8386,7 @@ impl wifi_csi_acquire_config_t {
 #[doc = " @brief HE variant HT Control field including OM(Operation mode)"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_htc_omc_t {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -8580,7 +8580,7 @@ pub const wifi_twt_setup_cmds_t_TWT_REJECT: wifi_twt_setup_cmds_t = 7;
 pub type wifi_twt_setup_cmds_t = crate::c_types::c_uint;
 #[doc = " @brief broadcast TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_btwt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8591,7 +8591,7 @@ pub struct wifi_btwt_setup_config_t {
 }
 #[doc = " @brief Individual TWT setup config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_setup_config_t {
     #[doc = "< Indicates the type of TWT command"]
     pub setup_cmd: wifi_twt_setup_cmds_t,
@@ -8745,7 +8745,7 @@ pub const wifi_rx_bb_format_t_RX_BB_FORMAT_VHT_MU: wifi_rx_bb_format_t = 11;
 #[doc = " @brief Reception format"]
 pub type wifi_rx_bb_format_t = crate::c_types::c_uint;
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_rxctrl_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -9032,7 +9032,7 @@ pub const wifi_btwt_setup_status_t_BTWT_SETUP_INTERNAL_ERR: wifi_btwt_setup_stat
 pub type wifi_btwt_setup_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_setup_t {
     #[doc = "< itwt setup config, this value is determined by the AP"]
     pub config: wifi_itwt_setup_config_t,
@@ -9051,7 +9051,7 @@ pub const wifi_itwt_teardown_status_t_ITWT_TEARDOWN_SUCCESS: wifi_itwt_teardown_
 pub type wifi_itwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_teardown_t {
     #[doc = "< flow id"]
     pub flow_id: u8,
@@ -9060,7 +9060,7 @@ pub struct wifi_event_sta_itwt_teardown_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_BTWT_SET_UP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_setup_t {
     #[doc = "< indicate btwt setup status"]
     pub status: wifi_btwt_setup_status_t,
@@ -9091,7 +9091,7 @@ pub const wifi_btwt_teardown_status_t_BTWT_TEARDOWN_SUCCESS: wifi_btwt_teardown_
 pub type wifi_btwt_teardown_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_TWT_TEARDOWN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_btwt_teardown_t {
     #[doc = "< btwt id"]
     pub btwt_id: u8,
@@ -9110,7 +9110,7 @@ pub const wifi_itwt_probe_status_t_ITWT_PROBE_STA_DISCONNECTED: wifi_itwt_probe_
 pub type wifi_itwt_probe_status_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SEND_PROBE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_probe_t {
     #[doc = "< probe status"]
     pub status: wifi_itwt_probe_status_t,
@@ -9119,7 +9119,7 @@ pub struct wifi_event_sta_itwt_probe_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_ITWT_SUSPEND event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_itwt_suspend_t {
     #[doc = "< suspend status"]
     pub status: esp_err_t,
@@ -9138,7 +9138,7 @@ pub const wifi_twt_type_t_TWT_TYPE_MAX: wifi_twt_type_t = 2;
 pub type wifi_twt_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for twt configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_twt_config_t {
     #[doc = "< post twt wakeup event"]
     pub post_wakeup_event: bool,
@@ -9147,7 +9147,7 @@ pub struct wifi_twt_config_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_TWT_WAKEUP event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_twt_wakeup_t {
     #[doc = "< twt type"]
     pub twt_type: wifi_twt_type_t,
@@ -9156,7 +9156,7 @@ pub struct wifi_event_sta_twt_wakeup_t {
 }
 #[doc = " Argument structure for twt information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_wifi_btwt_info_t {
     #[doc = "< indicate whether the btwt id is in use or not"]
     pub btwt_id_in_use: bool,
@@ -9316,7 +9316,7 @@ impl esp_wifi_btwt_info_t {
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 10usize],
@@ -9335,7 +9335,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -9360,7 +9360,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9791,7 +9791,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9818,7 +9818,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -9883,7 +9883,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -10396,7 +10396,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -10415,7 +10415,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -10461,7 +10461,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -10486,7 +10486,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -10503,7 +10503,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -10513,7 +10513,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -10521,7 +10521,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -10891,7 +10891,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -11290,7 +11290,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -11307,7 +11307,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -11411,13 +11411,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -11553,7 +11553,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -11612,7 +11612,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11724,7 +11724,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -11873,27 +11873,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -12409,7 +12409,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12574,7 +12574,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12624,7 +12624,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12773,7 +12773,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12906,7 +12906,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13009,7 +13009,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13307,7 +13307,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13520,7 +13520,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13808,7 +13808,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13928,7 +13928,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14119,7 +14119,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14215,7 +14215,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14278,7 +14278,7 @@ impl pmu_hp_regulator0_reg_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_4 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14347,7 +14347,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14397,7 +14397,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14464,7 +14464,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14565,7 +14565,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14615,7 +14615,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14665,7 +14665,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14734,7 +14734,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14835,7 +14835,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14946,7 +14946,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15215,7 +15215,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15318,7 +15318,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15372,7 +15372,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15426,7 +15426,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15480,7 +15480,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15551,7 +15551,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15656,7 +15656,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15737,7 +15737,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15822,7 +15822,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15907,7 +15907,7 @@ pub union pmu_power_wait_timer2_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer2_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15992,7 +15992,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16157,7 +16157,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16258,7 +16258,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16391,7 +16391,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16461,7 +16461,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16546,7 +16546,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16613,7 +16613,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16663,7 +16663,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16716,7 +16716,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16801,7 +16801,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16854,7 +16854,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16923,7 +16923,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16992,7 +16992,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17059,7 +17059,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17112,7 +17112,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17181,7 +17181,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17231,7 +17231,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17396,7 +17396,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17449,7 +17449,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17579,7 +17579,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17818,7 +17818,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17999,7 +17999,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18098,7 +18098,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18167,7 +18167,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18220,7 +18220,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18305,7 +18305,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18390,7 +18390,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18699,7 +18699,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18753,7 +18753,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19177,7 +19177,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -19331,7 +19331,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19490,7 +19490,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19617,7 +19617,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19669,7 +19669,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19732,7 +19732,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19827,7 +19827,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19870,7 +19870,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19878,7 +19878,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19973,7 +19973,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20100,7 +20100,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20143,7 +20143,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -20151,7 +20151,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20246,7 +20246,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20341,7 +20341,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20384,7 +20384,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -20399,7 +20399,7 @@ pub struct pmu_hp_param_t {
     pub reset_wait_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -20447,18 +20447,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -20478,13 +20478,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub wakeup_wait_cycle: u8,
@@ -20499,7 +20499,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub clock_domain_sync_time_us: u16,
@@ -20525,7 +20525,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -20630,7 +20630,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20830,7 +20830,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21140,7 +21140,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21401,7 +21401,7 @@ pub union modem_syscon_clk_conf_power_st_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_power_st_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21535,7 +21535,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21924,7 +21924,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22313,7 +22313,7 @@ pub union modem_syscon_wifi_bb_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_wifi_bb_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22348,7 +22348,7 @@ pub union modem_syscon_fe_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_fe_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22383,7 +22383,7 @@ pub union modem_syscon_mem_rf1_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_mem_rf1_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22419,7 +22419,7 @@ pub union modem_syscon_mem_rf2_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_mem_rf2_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22455,7 +22455,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22524,7 +22524,7 @@ pub union modem_lpcon_test_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_test_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22574,7 +22574,7 @@ pub union modem_lpcon_lp_timer_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_lp_timer_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22695,7 +22695,7 @@ pub union modem_lpcon_coex_lp_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_coex_lp_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22815,7 +22815,7 @@ pub union modem_lpcon_wifi_lp_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_wifi_lp_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -22937,7 +22937,7 @@ pub union modem_lpcon_modem_src_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_modem_src_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23006,7 +23006,7 @@ pub union modem_lpcon_modem_32k_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_modem_32k_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23059,7 +23059,7 @@ pub union modem_lpcon_clk_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23160,7 +23160,7 @@ pub union modem_lpcon_clk_conf_force_on_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_force_on_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23277,7 +23277,7 @@ pub union modem_lpcon_clk_conf_power_st_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_power_st_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23378,7 +23378,7 @@ pub union modem_lpcon_rst_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_rst_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23495,7 +23495,7 @@ pub union modem_lpcon_tick_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_tick_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23549,7 +23549,7 @@ pub union modem_lpcon_mem_conf_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_mem_conf_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23778,7 +23778,7 @@ pub union modem_lpcon_mem_rf1_aux_ctrl_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_mem_rf1_aux_ctrl_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23814,7 +23814,7 @@ pub union modem_lpcon_mem_rf2_aux_ctrl_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_mem_rf2_aux_ctrl_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23850,7 +23850,7 @@ pub union modem_lpcon_apb_mem_sel_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_apb_mem_sel_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23935,7 +23935,7 @@ pub union modem_lpcon_dcmem_valid_0_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_dcmem_valid_0_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -23970,7 +23970,7 @@ pub union modem_lpcon_dcmem_valid_1_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_dcmem_valid_1_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24005,7 +24005,7 @@ pub union modem_lpcon_dcmem_valid_2_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_dcmem_valid_2_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24040,7 +24040,7 @@ pub union modem_lpcon_dcmem_valid_3_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_dcmem_valid_3_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24075,7 +24075,7 @@ pub union modem_lpcon_date_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_date_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -24145,7 +24145,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -24363,7 +24363,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -24398,7 +24398,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Configuration version"]
     pub config_version: u32,
@@ -24551,7 +24551,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24636,7 +24636,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -24696,7 +24696,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -24876,7 +24876,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -24895,7 +24895,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -24906,7 +24906,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -24943,7 +24943,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -25064,7 +25064,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32h2/src/include.rs
+++ b/esp-wifi-sys-esp32h2/src/include.rs
@@ -3365,7 +3365,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3374,7 +3374,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3382,7 +3382,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3480,7 +3480,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3490,7 +3490,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3503,7 +3503,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3511,7 +3511,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3519,7 +3519,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3583,7 +3583,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3593,7 +3593,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3601,7 +3601,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3624,7 +3624,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4874,19 +4874,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5627,7 +5627,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5823,7 +5823,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5832,7 +5832,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5841,7 +5841,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5850,7 +5850,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5873,7 +5873,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5934,7 +5934,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5999,7 +5999,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6351,7 +6351,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6360,7 +6360,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6802,7 +6802,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6827,7 +6827,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -7056,14 +7056,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7107,7 +7107,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7124,7 +7124,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7223,7 +7223,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7244,7 +7244,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7291,7 +7291,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7398,7 +7398,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7505,7 +7505,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7522,7 +7522,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7533,7 +7533,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7544,7 +7544,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7738,7 +7738,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7749,7 +7749,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7766,7 +7766,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7781,7 +7781,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7790,7 +7790,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7811,7 +7811,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7819,7 +7819,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7828,7 +7828,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7839,7 +7839,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7852,7 +7852,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7861,14 +7861,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7897,7 +7897,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7916,7 +7916,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7947,7 +7947,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7962,7 +7962,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7975,7 +7975,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7992,7 +7992,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -8001,7 +8001,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8188,7 +8188,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8209,14 +8209,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8230,7 +8230,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8313,7 +8313,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8322,7 +8322,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8337,7 +8337,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8358,7 +8358,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8380,14 +8380,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -8397,7 +8397,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 28usize]>,
@@ -8699,7 +8699,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -8728,7 +8728,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -8753,7 +8753,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9184,7 +9184,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9211,7 +9211,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -9276,7 +9276,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -9789,7 +9789,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -9808,7 +9808,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -9854,7 +9854,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -9879,7 +9879,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -9896,7 +9896,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -9906,7 +9906,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -9914,7 +9914,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -10284,7 +10284,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -10677,7 +10677,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -10694,7 +10694,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -10798,13 +10798,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -10925,7 +10925,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -10984,7 +10984,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11096,7 +11096,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -11245,27 +11245,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -11909,7 +11909,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12074,7 +12074,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12124,7 +12124,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12273,7 +12273,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12406,7 +12406,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12525,7 +12525,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12823,7 +12823,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13036,7 +13036,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13324,7 +13324,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13441,7 +13441,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13654,7 +13654,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13704,7 +13704,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13771,7 +13771,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13872,7 +13872,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13922,7 +13922,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13972,7 +13972,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14073,7 +14073,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14190,7 +14190,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14301,7 +14301,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14570,7 +14570,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14673,7 +14673,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14727,7 +14727,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14781,7 +14781,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14835,7 +14835,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14906,7 +14906,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15011,7 +15011,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15092,7 +15092,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15177,7 +15177,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15262,7 +15262,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15427,7 +15427,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15528,7 +15528,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15661,7 +15661,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15731,7 +15731,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15816,7 +15816,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15882,7 +15882,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15932,7 +15932,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15985,7 +15985,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16070,7 +16070,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16123,7 +16123,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16192,7 +16192,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16261,7 +16261,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16328,7 +16328,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16381,7 +16381,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16450,7 +16450,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16500,7 +16500,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16617,7 +16617,7 @@ pub union pmu_vddbat_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_vddbat_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16686,7 +16686,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16739,7 +16739,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16870,7 +16870,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17109,7 +17109,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17290,7 +17290,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17362,12 +17362,12 @@ pub struct pmu_lp_ext_hw_regmap_t {
     pub pwr1: pmu_lp_cpu_pwr1_reg_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_lp_hw_regmap_t {
     pub common: pmu_hp_lp_hw_regmap_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_lp_hw_regmap_t__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -17398,7 +17398,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17467,7 +17467,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17520,7 +17520,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17605,7 +17605,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17690,7 +17690,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17999,7 +17999,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18053,7 +18053,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18475,7 +18475,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -18603,7 +18603,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18762,7 +18762,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18889,7 +18889,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18941,7 +18941,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19036,7 +19036,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19131,7 +19131,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19174,7 +19174,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19182,7 +19182,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19293,7 +19293,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19420,7 +19420,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19463,7 +19463,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -19471,7 +19471,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19566,7 +19566,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19661,7 +19661,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19704,7 +19704,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -19717,7 +19717,7 @@ pub struct pmu_hp_param_t {
     pub min_slp_slow_clk_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -19763,18 +19763,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -19794,13 +19794,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub reserved0: u8,
@@ -19813,7 +19813,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub analog_wait_time_us: u16,
@@ -19831,7 +19831,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -19935,7 +19935,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19985,7 +19985,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20198,7 +20198,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20347,7 +20347,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20640,7 +20640,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20805,7 +20805,7 @@ pub union modem_syscon_clk_conf1_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_clk_conf1_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20906,7 +20906,7 @@ pub union modem_syscon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20991,7 +20991,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21056,7 +21056,7 @@ pub union modem_lpcon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21106,7 +21106,7 @@ pub union modem_lpcon_coex_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_coex_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21226,7 +21226,7 @@ pub union modem_lpcon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21343,7 +21343,7 @@ pub union modem_lpcon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21460,7 +21460,7 @@ pub union modem_lpcon_tick_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_tick_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21513,7 +21513,7 @@ pub union modem_lpcon_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21598,7 +21598,7 @@ pub union modem_lpcon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21861,7 +21861,7 @@ pub union modem_lpcon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_lpcon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21919,7 +21919,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -22120,7 +22120,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -22155,7 +22155,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Version number of the defined structure"]
     pub config_version: u32,
@@ -22308,7 +22308,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -22397,7 +22397,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -22457,7 +22457,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -22638,7 +22638,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -22680,7 +22680,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -22699,7 +22699,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -22710,7 +22710,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -22747,7 +22747,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -22868,7 +22868,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32h2/src/include.rs
+++ b/esp-wifi-sys-esp32h2/src/include.rs
@@ -3365,7 +3365,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -3374,7 +3374,7 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
@@ -3382,7 +3382,7 @@ pub struct timeval {
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __bindgen_padding_0: u64,
@@ -3480,7 +3480,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -3490,7 +3490,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -3503,7 +3503,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -3511,7 +3511,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -3519,7 +3519,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -3583,7 +3583,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -3593,7 +3593,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -3601,7 +3601,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -3624,7 +3624,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -4874,19 +4874,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -5627,7 +5627,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -5823,7 +5823,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -5832,7 +5832,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -5841,7 +5841,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -5850,7 +5850,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -5873,7 +5873,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -5934,7 +5934,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5999,7 +5999,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -6230,7 +6230,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -6351,7 +6351,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -6360,7 +6360,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -6369,7 +6369,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -6389,7 +6389,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -6398,7 +6398,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -6439,7 +6439,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -6802,7 +6802,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -6827,7 +6827,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -7056,14 +7056,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -7107,7 +7107,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -7124,7 +7124,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -7223,7 +7223,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7244,7 +7244,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -7291,7 +7291,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7398,7 +7398,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -7505,7 +7505,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -7522,7 +7522,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -7533,7 +7533,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -7544,7 +7544,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -7738,7 +7738,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -7749,7 +7749,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -7766,7 +7766,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -7781,7 +7781,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -7790,7 +7790,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7811,7 +7811,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -7819,7 +7819,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -7828,7 +7828,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -7839,7 +7839,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -7852,7 +7852,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -7861,14 +7861,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -7897,7 +7897,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -7916,7 +7916,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -7947,7 +7947,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -7962,7 +7962,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -7975,7 +7975,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -7992,7 +7992,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -8001,7 +8001,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -8188,7 +8188,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -8209,14 +8209,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -8230,7 +8230,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -8313,7 +8313,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -8322,7 +8322,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -8337,7 +8337,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -8358,7 +8358,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -8380,14 +8380,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -8397,7 +8397,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 28usize]>,
@@ -8699,7 +8699,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -8728,7 +8728,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -8753,7 +8753,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -9184,7 +9184,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -9211,7 +9211,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -9276,7 +9276,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -9789,7 +9789,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -9808,7 +9808,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -9854,7 +9854,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -9879,7 +9879,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -9896,7 +9896,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -9906,7 +9906,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -9914,7 +9914,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -10284,7 +10284,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -10677,7 +10677,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -10694,7 +10694,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -10798,13 +10798,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -10925,7 +10925,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -10984,7 +10984,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -11096,7 +11096,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -11245,27 +11245,27 @@ pub use self::ble_npl_error as ble_npl_error_t;
 pub type ble_npl_time_t = u32;
 pub type ble_npl_stime_t = i32;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_event {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_eventq {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_callout {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_mutex {
     pub dummy: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ble_npl_sem {
     pub dummy: crate::c_types::c_int,
 }
@@ -11909,7 +11909,7 @@ pub union pmu_hp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12074,7 +12074,7 @@ pub union pmu_hp_icg_modem_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_icg_modem_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12124,7 +12124,7 @@ pub union pmu_hp_sys_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sys_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12273,7 +12273,7 @@ pub union pmu_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12406,7 +12406,7 @@ pub union pmu_hp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12525,7 +12525,7 @@ pub union pmu_hp_backup_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -12823,7 +12823,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13036,7 +13036,7 @@ impl pmu_hp_backup_reg_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_backup_reg_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13324,7 +13324,7 @@ pub union pmu_hp_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13441,7 +13441,7 @@ pub union pmu_hp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13654,7 +13654,7 @@ pub union pmu_hp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13704,7 +13704,7 @@ pub union pmu_hp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13771,7 +13771,7 @@ pub union pmu_lp_regulator0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13872,7 +13872,7 @@ pub union pmu_lp_regulator1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_regulator1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13922,7 +13922,7 @@ pub union pmu_lp_xtal_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_xtal_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -13972,7 +13972,7 @@ pub union pmu_lp_dig_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_dig_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14073,7 +14073,7 @@ pub union pmu_lp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14190,7 +14190,7 @@ pub union pmu_lp_bias_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_bias_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14301,7 +14301,7 @@ pub union pmu_imm_hp_clk_power_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_clk_power_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14570,7 +14570,7 @@ pub union pmu_imm_sleep_sysclk_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_sleep_sysclk_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14673,7 +14673,7 @@ pub union pmu_imm_hp_func_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_func_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14727,7 +14727,7 @@ pub union pmu_imm_hp_apb_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_hp_apb_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14781,7 +14781,7 @@ pub union pmu_imm_modem_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_modem_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14835,7 +14835,7 @@ pub union pmu_imm_lp_icg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_lp_icg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -14906,7 +14906,7 @@ pub union pmu_imm_pad_hold_all_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_pad_hold_all_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15011,7 +15011,7 @@ pub union pmu_imm_i2c_isolate_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_imm_i2c_isolate_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15092,7 +15092,7 @@ pub union pmu_power_wait_timer0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15177,7 +15177,7 @@ pub union pmu_power_wait_timer1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_wait_timer1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15262,7 +15262,7 @@ pub union pmu_power_domain_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_domain_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15427,7 +15427,7 @@ pub union pmu_power_memory_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15528,7 +15528,7 @@ pub union pmu_power_memory_mask_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_memory_mask_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15661,7 +15661,7 @@ pub union pmu_power_hp_pad_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_hp_pad_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15731,7 +15731,7 @@ pub union pmu_power_vdd_spi_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_vdd_spi_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15816,7 +15816,7 @@ pub union pmu_power_clk_wait_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_power_clk_wait_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15882,7 +15882,7 @@ pub union pmu_slp_wakeup_cntl0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15932,7 +15932,7 @@ pub union pmu_slp_wakeup_cntl1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -15985,7 +15985,7 @@ pub union pmu_slp_wakeup_cntl3_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl3_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16070,7 +16070,7 @@ pub union pmu_slp_wakeup_cntl4_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl4_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16123,7 +16123,7 @@ pub union pmu_slp_wakeup_cntl5_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl5_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16192,7 +16192,7 @@ pub union pmu_slp_wakeup_cntl6_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl6_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16261,7 +16261,7 @@ pub union pmu_slp_wakeup_cntl7_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_slp_wakeup_cntl7_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16328,7 +16328,7 @@ pub union pmu_hp_clk_poweron_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_poweron_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16381,7 +16381,7 @@ pub union pmu_hp_clk_cntl_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_clk_cntl_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16450,7 +16450,7 @@ pub union pmu_por_status_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_por_status_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16500,7 +16500,7 @@ pub union pmu_rf_pwc_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_rf_pwc_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16617,7 +16617,7 @@ pub union pmu_vddbat_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_vddbat_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16686,7 +16686,7 @@ pub union pmu_backup_cfg_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_backup_cfg_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16739,7 +16739,7 @@ pub union pmu_hp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -16870,7 +16870,7 @@ pub union pmu_lp_intr_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_intr_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17109,7 +17109,7 @@ pub union pmu_lp_cpu_pwr0_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr0_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17290,7 +17290,7 @@ pub union pmu_lp_cpu_pwr1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_cpu_pwr1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17362,12 +17362,12 @@ pub struct pmu_lp_ext_hw_regmap_t {
     pub pwr1: pmu_lp_cpu_pwr1_reg_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_lp_hw_regmap_t {
     pub common: pmu_hp_lp_hw_regmap_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_lp_hw_regmap_t__bindgen_ty_1 {}
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -17398,7 +17398,7 @@ pub union pmu_dev_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_1__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17467,7 +17467,7 @@ pub union pmu_dev_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17520,7 +17520,7 @@ pub union pmu_dev_t__bindgen_ty_3 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_3__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17605,7 +17605,7 @@ pub union pmu_dev_t__bindgen_ty_4 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_4__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17690,7 +17690,7 @@ pub union pmu_dev_t__bindgen_ty_5 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -17999,7 +17999,7 @@ pub union pmu_dev_t__bindgen_ty_6 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_6__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18053,7 +18053,7 @@ pub union pmu_dev_t__bindgen_ty_7 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_dev_t__bindgen_ty_7__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18475,7 +18475,7 @@ extern "C" {
     pub fn strsignal(__signo: crate::c_types::c_int) -> *mut crate::c_types::c_char;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hal_context_t {
     pub dev: *mut pmu_dev_t,
 }
@@ -18603,7 +18603,7 @@ pub union pmu_hp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18762,7 +18762,7 @@ impl pmu_hp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18889,7 +18889,7 @@ impl pmu_hp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -18941,7 +18941,7 @@ pub union pmu_lp_power_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19036,7 +19036,7 @@ impl pmu_lp_power_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19131,7 +19131,7 @@ impl pmu_lp_power_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_power_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19174,7 +19174,7 @@ impl pmu_lp_power_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t {
     pub __bindgen_anon_1: pmu_hp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_hp_analog_t__bindgen_ty_2,
@@ -19182,7 +19182,7 @@ pub struct pmu_hp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19293,7 +19293,7 @@ impl pmu_hp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19420,7 +19420,7 @@ impl pmu_hp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19463,7 +19463,7 @@ impl pmu_hp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t {
     pub __bindgen_anon_1: pmu_lp_analog_t__bindgen_ty_1,
     pub __bindgen_anon_2: pmu_lp_analog_t__bindgen_ty_2,
@@ -19471,7 +19471,7 @@ pub struct pmu_lp_analog_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19566,7 +19566,7 @@ impl pmu_lp_analog_t__bindgen_ty_1 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_2 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19661,7 +19661,7 @@ impl pmu_lp_analog_t__bindgen_ty_2 {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_analog_t__bindgen_ty_3 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19704,7 +19704,7 @@ impl pmu_lp_analog_t__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_hp_param_t {
     pub modem_wakeup_wait_cycle: u32,
     pub analog_wait_target_cycle: u16,
@@ -19717,7 +19717,7 @@ pub struct pmu_hp_param_t {
     pub min_slp_slow_clk_cycle: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_lp_param_t {
     pub digital_power_supply_wait_cycle: u16,
     pub min_slp_slow_clk_cycle: u8,
@@ -19763,18 +19763,18 @@ pub struct pmu_sleep_digital_config_t {
     pub icg_func: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t {
     pub hp_sys: pmu_sleep_analog_config_t__bindgen_ty_1,
     pub lp_sys: [pmu_sleep_analog_config_t__bindgen_ty_2; 2usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_1 {
     pub analog: pmu_hp_analog_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_analog_config_t__bindgen_ty_2 {
     pub analog: pmu_lp_analog_t,
 }
@@ -19794,13 +19794,13 @@ pub struct pmu_sleep_config_t {
     pub param: pmu_sleep_param_config_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant {
     pub lp: pmu_sleep_machine_constant__bindgen_ty_1,
     pub hp: pmu_sleep_machine_constant__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub min_slp_time_us: u16,
     pub reserved0: u8,
@@ -19813,7 +19813,7 @@ pub struct pmu_sleep_machine_constant__bindgen_ty_1 {
     pub power_up_wait_time_us: u16,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_sleep_machine_constant__bindgen_ty_2 {
     pub min_slp_time_us: u16,
     pub analog_wait_time_us: u16,
@@ -19831,7 +19831,7 @@ pub const pmu_hp_icg_modem_mode_t_PMU_HP_ICG_MODEM_CODE_ACTIVE: pmu_hp_icg_modem
 #[doc = " @brief PMU ICG modem code of HP system\n @note  This type is required in rtc_clk_init.c when PMU not fully supported"]
 pub type pmu_hp_icg_modem_mode_t = crate::c_types::c_uint;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct pmu_context_t {
     pub hal: *mut pmu_hal_context_t,
     pub mc: *mut crate::c_types::c_void,
@@ -19935,7 +19935,7 @@ pub union modem_syscon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -19985,7 +19985,7 @@ pub union modem_syscon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20198,7 +20198,7 @@ pub union modem_syscon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20347,7 +20347,7 @@ pub union modem_syscon_modem_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_modem_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20640,7 +20640,7 @@ pub union modem_syscon_clk_conf1_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf1_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20805,7 +20805,7 @@ pub union modem_syscon_clk_conf1_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_clk_conf1_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20906,7 +20906,7 @@ pub union modem_syscon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -20991,7 +20991,7 @@ pub union modem_syscon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_syscon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21056,7 +21056,7 @@ pub union modem_lpcon_test_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_test_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21106,7 +21106,7 @@ pub union modem_lpcon_coex_lp_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_coex_lp_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21226,7 +21226,7 @@ pub union modem_lpcon_clk_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21343,7 +21343,7 @@ pub union modem_lpcon_clk_conf_force_on_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_clk_conf_force_on_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21460,7 +21460,7 @@ pub union modem_lpcon_tick_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_tick_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21513,7 +21513,7 @@ pub union modem_lpcon_rst_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_rst_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21598,7 +21598,7 @@ pub union modem_lpcon_mem_conf_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_mem_conf_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21861,7 +21861,7 @@ pub union modem_lpcon_date_reg_t {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_lpcon_date_reg_t__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -21919,7 +21919,7 @@ extern "C" {
     pub static mut MODEM_LPCON: modem_lpcon_dev_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct modem_clock_hal_context_t {
     pub syscon_dev: *mut modem_syscon_dev_t,
     pub lpcon_dev: *mut modem_lpcon_dev_t,
@@ -22120,7 +22120,7 @@ pub const esp_ble_log_buf_t_ESP_BLE_LOG_BUF_CONTROLLER: esp_ble_log_buf_t = 5;
 pub type esp_ble_log_buf_t = crate::c_types::c_uint;
 #[doc = " @brief Address type and address value."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ble_addr_t {
     #[doc = "< Type of the Bluetooth address (public, random, etc.)"]
     pub type_: u8,
@@ -22155,7 +22155,7 @@ extern "C" {
 }
 #[doc = " @brief Controller config options, depend on config mask.\n        Config mask indicate which functions enabled, this means\n        some options or parameters of some functions enabled by config mask."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Version number of the defined structure"]
     pub config_version: u32,
@@ -22308,7 +22308,7 @@ extern "C" {
 }
 #[doc = " @brief esp_vhci_host_callback\n  used for vhci call host function to notify what host need to do"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the host can send packet to controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -22397,7 +22397,7 @@ extern "C" {
     pub fn esp_coex_wifi_i154_enable() -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -22457,7 +22457,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -22638,7 +22638,7 @@ pub const ieee802154_coex_event_t_IEEE802154_EVENT_MAX: ieee802154_coex_event_t 
 pub type ieee802154_coex_event_t = crate::c_types::c_uint;
 #[doc = " @brief 802.15.4 coexistence configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_ieee802154_coex_config_t {
     pub idle: ieee802154_coex_event_t,
     pub txrx: ieee802154_coex_event_t,
@@ -22680,7 +22680,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -22699,7 +22699,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -22710,7 +22710,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -22747,7 +22747,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -22868,7 +22868,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32s2/src/include.rs
+++ b/esp-wifi-sys-esp32s2/src/include.rs
@@ -1723,7 +1723,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1732,14 +1732,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -1836,7 +1836,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1846,7 +1846,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1859,7 +1859,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1867,7 +1867,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -1875,7 +1875,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -1939,7 +1939,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -1949,7 +1949,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -1957,7 +1957,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -1980,7 +1980,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3230,19 +3230,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -3983,7 +3983,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4179,7 +4179,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4188,7 +4188,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4197,7 +4197,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4206,7 +4206,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4229,7 +4229,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4290,7 +4290,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4355,7 +4355,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4707,7 +4707,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4716,7 +4716,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5158,7 +5158,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5183,7 +5183,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5412,14 +5412,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5463,7 +5463,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5480,7 +5480,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5579,7 +5579,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5600,7 +5600,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5647,7 +5647,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5754,7 +5754,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5861,7 +5861,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -5878,7 +5878,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -5889,7 +5889,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -5900,7 +5900,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6086,7 +6086,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6097,7 +6097,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6114,7 +6114,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6129,7 +6129,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6138,7 +6138,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6159,7 +6159,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6167,7 +6167,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6176,7 +6176,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6187,7 +6187,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6200,7 +6200,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6209,14 +6209,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6245,7 +6245,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6264,7 +6264,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6295,7 +6295,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6310,7 +6310,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6323,7 +6323,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6340,7 +6340,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6349,7 +6349,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6536,7 +6536,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6557,14 +6557,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6578,7 +6578,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6661,7 +6661,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6670,7 +6670,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6685,7 +6685,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6706,7 +6706,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6728,14 +6728,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -6745,7 +6745,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 36usize]>,
@@ -6962,7 +6962,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -6991,7 +6991,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7016,7 +7016,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7447,7 +7447,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7474,7 +7474,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7539,7 +7539,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8052,7 +8052,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8071,7 +8071,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8117,7 +8117,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8142,7 +8142,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8159,7 +8159,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8169,7 +8169,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8177,7 +8177,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8547,7 +8547,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -8942,7 +8942,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -8959,7 +8959,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9063,13 +9063,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9194,7 +9194,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9253,7 +9253,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9365,7 +9365,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9503,7 +9503,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -9522,7 +9522,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -9533,7 +9533,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -9570,7 +9570,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -9691,7 +9691,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32s2/src/include.rs
+++ b/esp-wifi-sys-esp32s2/src/include.rs
@@ -1723,7 +1723,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -1732,14 +1732,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -1836,7 +1836,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -1846,7 +1846,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -1859,7 +1859,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -1867,7 +1867,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -1875,7 +1875,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -1939,7 +1939,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -1949,7 +1949,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -1957,7 +1957,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -1980,7 +1980,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3230,19 +3230,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -3983,7 +3983,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4179,7 +4179,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4188,7 +4188,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4197,7 +4197,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4206,7 +4206,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4229,7 +4229,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4290,7 +4290,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4355,7 +4355,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -4586,7 +4586,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -4707,7 +4707,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -4716,7 +4716,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -4725,7 +4725,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -4745,7 +4745,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -4754,7 +4754,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -4795,7 +4795,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -5158,7 +5158,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5183,7 +5183,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5412,14 +5412,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5463,7 +5463,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5480,7 +5480,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -5579,7 +5579,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -5600,7 +5600,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -5647,7 +5647,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5754,7 +5754,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -5861,7 +5861,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -5878,7 +5878,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -5889,7 +5889,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -5900,7 +5900,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6086,7 +6086,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6097,7 +6097,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6114,7 +6114,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6129,7 +6129,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6138,7 +6138,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6159,7 +6159,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6167,7 +6167,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6176,7 +6176,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6187,7 +6187,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6200,7 +6200,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6209,14 +6209,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6245,7 +6245,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6264,7 +6264,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6295,7 +6295,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6310,7 +6310,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6323,7 +6323,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6340,7 +6340,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6349,7 +6349,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6536,7 +6536,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6557,14 +6557,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -6578,7 +6578,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -6661,7 +6661,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -6670,7 +6670,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -6685,7 +6685,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -6706,7 +6706,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -6728,14 +6728,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -6745,7 +6745,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 36usize]>,
@@ -6962,7 +6962,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -6991,7 +6991,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7016,7 +7016,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7447,7 +7447,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7474,7 +7474,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7539,7 +7539,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8052,7 +8052,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8071,7 +8071,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8117,7 +8117,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8142,7 +8142,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8159,7 +8159,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8169,7 +8169,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8177,7 +8177,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8547,7 +8547,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -8942,7 +8942,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -8959,7 +8959,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9063,13 +9063,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9194,7 +9194,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9253,7 +9253,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9365,7 +9365,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9503,7 +9503,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -9522,7 +9522,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -9533,7 +9533,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -9570,7 +9570,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -9691,7 +9691,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32s3/src/include.rs
+++ b/esp-wifi-sys-esp32s3/src/include.rs
@@ -2162,7 +2162,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -2171,14 +2171,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -2275,7 +2275,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -2285,7 +2285,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -2298,7 +2298,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -2306,7 +2306,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2314,7 +2314,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2378,7 +2378,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2388,7 +2388,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2396,7 +2396,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2419,7 +2419,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3669,19 +3669,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4422,7 +4422,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4618,7 +4618,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4627,7 +4627,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4636,7 +4636,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4645,7 +4645,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4668,7 +4668,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4729,7 +4729,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4794,7 +4794,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -5146,7 +5146,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -5155,7 +5155,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5597,7 +5597,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5622,7 +5622,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5851,14 +5851,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5902,7 +5902,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5919,7 +5919,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -6018,7 +6018,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6039,7 +6039,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -6086,7 +6086,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6193,7 +6193,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6300,7 +6300,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6317,7 +6317,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6328,7 +6328,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6339,7 +6339,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6525,7 +6525,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6536,7 +6536,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6553,7 +6553,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6568,7 +6568,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6577,7 +6577,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6598,7 +6598,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6606,7 +6606,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6615,7 +6615,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6626,7 +6626,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6639,7 +6639,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6648,14 +6648,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6684,7 +6684,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6703,7 +6703,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6734,7 +6734,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6749,7 +6749,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6762,7 +6762,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6779,7 +6779,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6788,7 +6788,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6975,7 +6975,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6996,14 +6996,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -7017,7 +7017,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -7100,7 +7100,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -7109,7 +7109,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -7124,7 +7124,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -7145,7 +7145,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -7167,14 +7167,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -7184,7 +7184,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -7401,7 +7401,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7430,7 +7430,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7455,7 +7455,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7886,7 +7886,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7913,7 +7913,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7978,7 +7978,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8491,7 +8491,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8510,7 +8510,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8556,7 +8556,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8581,7 +8581,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8598,7 +8598,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8608,7 +8608,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8616,7 +8616,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8986,7 +8986,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9379,7 +9379,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9396,7 +9396,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9500,13 +9500,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9631,7 +9631,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9690,7 +9690,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9802,7 +9802,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9991,7 +9991,7 @@ pub type esp_bt_hci_tl_callback_t =
     ::core::option::Option<unsafe extern "C" fn(arg: *mut crate::c_types::c_void, status: u8)>;
 #[doc = " @brief Controller HCI transport layer function structure\n\n @note This structure must be registered when HCI transport layer is UART"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_hci_tl_t {
     #[doc = "< Magic number"]
     pub _magic: u32,
@@ -10030,7 +10030,7 @@ pub struct esp_bt_hci_tl_t {
 }
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Magic number"]
     pub magic: u32,
@@ -10303,7 +10303,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the Host can send the HCI data to Controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10371,7 +10371,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10431,7 +10431,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10611,7 +10611,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10630,7 +10630,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10641,7 +10641,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10678,7 +10678,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10799,7 +10799,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/esp-wifi-sys-esp32s3/src/include.rs
+++ b/esp-wifi-sys-esp32s3/src/include.rs
@@ -2162,7 +2162,7 @@ pub type QueueHandle_t = *mut crate::c_types::c_void;
 pub type esp_netif_t = *mut crate::c_types::c_void;
 pub type esp_netif_inherent_config_t = *mut crate::c_types::c_void;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ets_timer {
     pub next: *mut timer_adpt,
     pub expire: u32,
@@ -2171,14 +2171,14 @@ pub struct ets_timer {
     pub priv_: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timeval {
     pub tv_sec: u64,
     pub tv_usec: u32,
 }
 pub type wchar_t = crate::c_types::c_int;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: crate::c_types::c_longlong,
     pub __clang_max_align_nonce2: f64,
@@ -2275,7 +2275,7 @@ pub struct __locale_t {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _Bigint {
     pub _next: *mut _Bigint,
     pub _k: crate::c_types::c_int,
@@ -2285,7 +2285,7 @@ pub struct _Bigint {
     pub _x: [__ULong; 1usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __tm {
     pub __tm_sec: crate::c_types::c_int,
     pub __tm_min: crate::c_types::c_int,
@@ -2298,7 +2298,7 @@ pub struct __tm {
     pub __tm_isdst: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _on_exit_args {
     pub _fnargs: [*mut crate::c_types::c_void; 32usize],
     pub _dso_handle: [*mut crate::c_types::c_void; 32usize],
@@ -2306,7 +2306,7 @@ pub struct _on_exit_args {
     pub _is_cxa: __ULong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _atexit {
     pub _next: *mut _atexit,
     pub _ind: crate::c_types::c_int,
@@ -2314,7 +2314,7 @@ pub struct _atexit {
     pub _on_exit_args_ptr: *mut _on_exit_args,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct __sbuf {
     pub _base: *mut crate::c_types::c_uchar,
     pub _size: crate::c_types::c_int,
@@ -2378,7 +2378,7 @@ extern "C" {
     pub static mut __sf: [__FILE; 3usize];
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _glue {
     pub _next: *mut _glue,
     pub _niobs: crate::c_types::c_int,
@@ -2388,7 +2388,7 @@ extern "C" {
     pub static mut __sglue: _glue;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _rand48 {
     pub _seed: [crate::c_types::c_ushort; 3usize],
     pub _mult: [crate::c_types::c_ushort; 3usize],
@@ -2396,7 +2396,7 @@ pub struct _rand48 {
     pub _rand_next: crate::c_types::c_ulonglong,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _mprec {
     pub _result: *mut _Bigint,
     pub _result_k: crate::c_types::c_int,
@@ -2419,7 +2419,7 @@ pub struct _misc_reent {
     pub _wcsrtombs_state: _mbstate_t,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct _reent {
     pub _errno: crate::c_types::c_int,
     pub _stdin: *mut __FILE,
@@ -3669,19 +3669,19 @@ extern "C" {
     ) -> *mut FILE;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct div_t {
     pub quot: crate::c_types::c_int,
     pub rem: crate::c_types::c_int,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct ldiv_t {
     pub quot: crate::c_types::c_long,
     pub rem: crate::c_types::c_long,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct lldiv_t {
     pub quot: crate::c_types::c_longlong,
     pub rem: crate::c_types::c_longlong,
@@ -4422,7 +4422,7 @@ pub const wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL: wifi_country_policy_
 pub type wifi_country_policy_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing Wi-Fi country-based regional restrictions."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_country_t {
     #[doc = "< Country code string"]
     pub cc: [crate::c_types::c_char; 3usize],
@@ -4618,7 +4618,7 @@ pub const wifi_scan_type_t_WIFI_SCAN_TYPE_PASSIVE: wifi_scan_type_t = 1;
 pub type wifi_scan_type_t = crate::c_types::c_uint;
 #[doc = " @brief Range of active scan times per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_active_scan_time_t {
     #[doc = "< Minimum active scan time per channel, units: millisecond"]
     pub min: u32,
@@ -4627,7 +4627,7 @@ pub struct wifi_active_scan_time_t {
 }
 #[doc = " @brief Aggregate of active & passive scan time per channel"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_time_t {
     #[doc = "< Active scan time per channel, units: millisecond."]
     pub active: wifi_active_scan_time_t,
@@ -4636,7 +4636,7 @@ pub struct wifi_scan_time_t {
 }
 #[doc = " @brief Channel bitmap for setting specific channels to be scanned"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_channel_bitmap_t {
     #[doc = "< Represents 2.4 GHz channels, that bits can be set as wifi_2g_channel_bit_t shown."]
     pub ghz_2_channels: u16,
@@ -4645,7 +4645,7 @@ pub struct wifi_scan_channel_bitmap_t {
 }
 #[doc = " @brief Parameters for an SSID scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_config_t {
     #[doc = "< SSID of AP"]
     pub ssid: *mut u8,
@@ -4668,7 +4668,7 @@ pub struct wifi_scan_config_t {
 }
 #[doc = " @brief Parameters default scan configurations"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_default_params_t {
     #[doc = "< Scan time per channel"]
     pub scan_time: wifi_scan_time_t,
@@ -4729,7 +4729,7 @@ pub const wifi_ant_t_WIFI_ANT_MAX: wifi_ant_t = 2;
 pub type wifi_ant_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi AP HE Info"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_he_ap_info_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -4794,7 +4794,7 @@ impl wifi_he_ap_info_t {
 }
 #[doc = " @brief Description of a Wi-Fi AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_record_t {
     #[doc = "< MAC address of AP"]
     pub bssid: [u8; 6usize],
@@ -5025,7 +5025,7 @@ pub const wifi_sort_method_t_WIFI_CONNECT_AP_BY_SECURITY: wifi_sort_method_t = 1
 pub type wifi_sort_method_t = crate::c_types::c_uint;
 #[doc = " @brief Structure describing parameters for a Wi-Fi fast scan"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_scan_threshold_t {
     #[doc = "< The minimum rssi to accept in the fast scan mode. Defaults to -127 if set to >= 0"]
     pub rssi: i8,
@@ -5146,7 +5146,7 @@ pub const wifi_5g_channel_bit_t_WIFI_CHANNEL_177: wifi_5g_channel_bit_t = 268435
 pub type wifi_5g_channel_bit_t = crate::c_types::c_uint;
 #[doc = " @brief Description of a Wi-Fi protocols"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_protocols_t {
     #[doc = "< Represents 2.4 GHz protocol, support 802.11b or 802.11g or 802.11n or 802.11ax or LR mode"]
     pub ghz_2g: u16,
@@ -5155,7 +5155,7 @@ pub struct wifi_protocols_t {
 }
 #[doc = " @brief Description of a Wi-Fi band bandwidths"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bandwidths_t {
     #[doc = "< Represents 2.4 GHz bandwidth"]
     pub ghz_2g: wifi_bandwidth_t,
@@ -5164,7 +5164,7 @@ pub struct wifi_bandwidths_t {
 }
 #[doc = " @brief Configuration structure for Protected Management Frame"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pmf_config_t {
     #[doc = "< Deprecated variable. Device will always connect in PMF mode if other device also advertises PMF capability."]
     pub capable: bool,
@@ -5184,7 +5184,7 @@ pub const wifi_sae_pk_mode_t_WPA3_SAE_PK_MODE_DISABLED: wifi_sae_pk_mode_t = 2;
 pub type wifi_sae_pk_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration structure for BSS max idle"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_bss_max_idle_config_t {
     #[doc = "< Sets BSS Max idle period (1 Unit = 1000TUs OR 1.024 Seconds). If there are no frames for this period from a STA, SoftAP will disassociate due to inactivity. Setting it to 0 disables the feature"]
     pub period: u16,
@@ -5193,7 +5193,7 @@ pub struct wifi_bss_max_idle_config_t {
 }
 #[doc = " @brief Soft-AP configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ap_config_t {
     #[doc = "< SSID of soft-AP. If ssid_len field is 0, this must be a Null terminated string. Otherwise, length is set according to ssid_len."]
     pub ssid: [u8; 32usize],
@@ -5234,7 +5234,7 @@ pub struct wifi_ap_config_t {
 }
 #[doc = " @brief STA configuration settings for the device"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_config_t {
     #[doc = "< SSID of target AP."]
     pub ssid: [u8; 32usize],
@@ -5597,7 +5597,7 @@ impl wifi_sta_config_t {
 }
 #[doc = " @brief NAN Discovery start configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_config_t {
     #[doc = "< NAN Discovery operating channel"]
     pub op_channel: u8,
@@ -5622,7 +5622,7 @@ pub union wifi_config_t {
 #[doc = " @brief Description of STA associated with AP"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_info_t {
     #[doc = "< MAC address"]
     pub mac: [u8; 6usize],
@@ -5851,14 +5851,14 @@ pub const wifi_promiscuous_pkt_type_t_WIFI_PKT_MISC: wifi_promiscuous_pkt_type_t
 pub type wifi_promiscuous_pkt_type_t = crate::c_types::c_uint;
 #[doc = " @brief Mask for filtering different packet types in promiscuous mode"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_promiscuous_filter_t {
     #[doc = "< OR of one or more filter values WIFI_PROMIS_FILTER_*"]
     pub filter_mask: u32,
 }
 #[doc = " @brief Wi-Fi GPIO configuration for antenna selection\n"]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_t {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -5902,7 +5902,7 @@ impl wifi_ant_gpio_t {
 }
 #[doc = " @brief Wi-Fi GPIOs configuration for antenna selection\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_gpio_config_t {
     #[doc = "< The configurations of GPIOs that connect to external antenna switch"]
     pub gpio_cfg: [wifi_ant_gpio_t; 4usize],
@@ -5919,7 +5919,7 @@ pub const wifi_ant_mode_t_WIFI_ANT_MODE_MAX: wifi_ant_mode_t = 3;
 pub type wifi_ant_mode_t = crate::c_types::c_uint;
 #[doc = " @brief Wi-Fi antenna configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ant_config_t {
     #[doc = "< Wi-Fi antenna mode for receiving"]
     pub rx_ant_mode: wifi_ant_mode_t,
@@ -6018,7 +6018,7 @@ pub type wifi_action_roc_done_cb_t = ::core::option::Option<
 >;
 #[doc = " @brief Remain on Channel request\n\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_roc_req_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6039,7 +6039,7 @@ pub struct wifi_roc_req_t {
 }
 #[doc = " @brief FTM Initiator configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_initiator_cfg_t {
     #[doc = "< MAC address of the FTM Responder"]
     pub resp_mac: [u8; 6usize],
@@ -6086,7 +6086,7 @@ pub const wifi_nan_service_type_t_NAN_SUBSCRIBE_PASSIVE: wifi_nan_service_type_t
 pub type wifi_nan_service_type_t = crate::c_types::c_uint;
 #[doc = " @brief NAN Publish service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_publish_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6193,7 +6193,7 @@ impl wifi_nan_publish_cfg_t {
 }
 #[doc = " @brief NAN Subscribe service configuration parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_subscribe_cfg_t {
     #[doc = "< Service name identifier"]
     pub service_name: [crate::c_types::c_char; 256usize],
@@ -6300,7 +6300,7 @@ impl wifi_nan_subscribe_cfg_t {
 }
 #[doc = " @brief NAN Follow-up parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_followup_params_t {
     #[doc = "< Own service instance id"]
     pub inst_id: u8,
@@ -6317,7 +6317,7 @@ pub struct wifi_nan_followup_params_t {
 }
 #[doc = " @brief NAN Datapath Request parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_req_t {
     #[doc = "< Publisher's service instance id"]
     pub pub_id: u8,
@@ -6328,7 +6328,7 @@ pub struct wifi_nan_datapath_req_t {
 }
 #[doc = " @brief NAN Datapath Response parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_resp_t {
     #[doc = "< True - Accept incoming NDP, False - Reject it"]
     pub accept: bool,
@@ -6339,7 +6339,7 @@ pub struct wifi_nan_datapath_resp_t {
 }
 #[doc = " @brief NAN Datapath End parameters\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_nan_datapath_end_req_t {
     #[doc = "< NAN Datapath Identifier"]
     pub ndp_id: u8,
@@ -6525,7 +6525,7 @@ extern "C" {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_SCAN_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_scan_done_t {
     #[doc = "< Status of scanning APs: 0 — success, 1 - failure"]
     pub status: u32,
@@ -6536,7 +6536,7 @@ pub struct wifi_event_sta_scan_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_CONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_connected_t {
     #[doc = "< SSID of connected AP"]
     pub ssid: [u8; 32usize],
@@ -6553,7 +6553,7 @@ pub struct wifi_event_sta_connected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_DISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_disconnected_t {
     #[doc = "< SSID of disconnected AP"]
     pub ssid: [u8; 32usize],
@@ -6568,7 +6568,7 @@ pub struct wifi_event_sta_disconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_AUTHMODE_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_authmode_change_t {
     #[doc = "< Old auth mode of AP"]
     pub old_mode: wifi_auth_mode_t,
@@ -6577,7 +6577,7 @@ pub struct wifi_event_sta_authmode_change_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6598,7 +6598,7 @@ pub const wifi_event_sta_wps_fail_reason_t_WPS_FAIL_REASON_MAX: wifi_event_sta_w
 pub type wifi_event_sta_wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_WPS_ER_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t {
     #[doc = "< Number of AP credentials received"]
     pub ap_cred_cnt: u8,
@@ -6606,7 +6606,7 @@ pub struct wifi_event_sta_wps_er_success_t {
     pub ap_cred: [wifi_event_sta_wps_er_success_t__bindgen_ty_1; 3usize],
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
     #[doc = "< SSID of AP"]
     pub ssid: [u8; 32usize],
@@ -6615,7 +6615,7 @@ pub struct wifi_event_sta_wps_er_success_t__bindgen_ty_1 {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STACONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_staconnected_t {
     #[doc = "< MAC address of the station connected to Soft-AP"]
     pub mac: [u8; 6usize],
@@ -6626,7 +6626,7 @@ pub struct wifi_event_ap_staconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_STADISCONNECTED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_stadisconnected_t {
     #[doc = "< MAC address of the station disconnects from the soft-AP"]
     pub mac: [u8; 6usize],
@@ -6639,7 +6639,7 @@ pub struct wifi_event_ap_stadisconnected_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_PROBEREQRECVED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_probe_req_rx_t {
     #[doc = "< Received probe request signal strength"]
     pub rssi: crate::c_types::c_int,
@@ -6648,14 +6648,14 @@ pub struct wifi_event_ap_probe_req_rx_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_STA_BSS_RSSI_LOW event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_bss_rssi_low_t {
     #[doc = "< RSSI value of bss"]
     pub rssi: i32,
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_HOME_CHANNEL_CHANGE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_home_channel_change_t {
     #[doc = "< Old home channel of the device"]
     pub old_chan: u8,
@@ -6684,7 +6684,7 @@ pub const wifi_ftm_status_t_FTM_STATUS_USER_TERM: wifi_ftm_status_t = 6;
 pub type wifi_ftm_status_t = crate::c_types::c_uint;
 #[doc = " @brief Structure representing a report entry for Fine Timing Measurement (FTM) in Wi-Fi.\n\n This structure holds the information related to the FTM process between a Wi-Fi FTM Initiator\n and a Wi-Fi FTM Responder. FTM is used for precise distance measurement by timing the exchange\n of frames between devices."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ftm_report_entry_t {
     #[doc = "< Dialog Token of the FTM frame"]
     pub dlog_token: u8,
@@ -6703,7 +6703,7 @@ pub struct wifi_ftm_report_entry_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_FTM_REPORT event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ftm_report_t {
     #[doc = "< MAC address of the FTM Peer"]
     pub peer_mac: [u8; 6usize],
@@ -6734,7 +6734,7 @@ pub const wifi_action_tx_status_type_t_WIFI_ACTION_TX_OP_CANCELLED: wifi_action_
 pub type wifi_action_tx_status_type_t = crate::c_types::c_uint;
 #[doc = " Argument structure for WIFI_EVENT_ACTION_TX_STATUS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_action_tx_status_t {
     #[doc = "< WiFi interface to send request to"]
     pub ifx: wifi_interface_t,
@@ -6749,7 +6749,7 @@ pub struct wifi_event_action_tx_status_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_ROC_DONE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_roc_done_t {
     #[doc = "< Context to identify the initiator of the request"]
     pub context: u32,
@@ -6762,7 +6762,7 @@ pub struct wifi_event_roc_done_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_PIN event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_pin_t {
     #[doc = "< PIN code of station in enrollee mode"]
     pub pin_code: [u8; 8usize],
@@ -6779,7 +6779,7 @@ pub const wps_fail_reason_t_WPS_AP_FAIL_REASON_MAX: wps_fail_reason_t = 3;
 pub type wps_fail_reason_t = crate::c_types::c_uint;
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_FAILED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_fail_reason_t {
     #[doc = "< WPS failure reason wps_fail_reason_t"]
     pub reason: wps_fail_reason_t,
@@ -6788,7 +6788,7 @@ pub struct wifi_event_ap_wps_rg_fail_reason_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_AP_WPS_RG_SUCCESS event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wps_rg_success_t {
     #[doc = "< Enrollee mac address"]
     pub peer_macaddr: [u8; 6usize],
@@ -6975,7 +6975,7 @@ pub struct wifi_event_ndp_confirm_t {
 }
 #[doc = " @brief Argument structure for WIFI_EVENT_NDP_TERMINATED event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ndp_terminated_t {
     #[doc = "< Termination reason code"]
     pub reason: u8,
@@ -6996,14 +6996,14 @@ pub struct wifi_event_neighbor_report_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_AP_WRONG_PASSWORD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_ap_wrong_password_t {
     #[doc = "< MAC address of the station trying to connect to Soft-AP"]
     pub mac: [u8; 6usize],
 }
 #[doc = " @brief Argument structure for wifi_tx_rate_config"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_rate_config_t {
     #[doc = "< Phymode of specified interface"]
     pub phymode: wifi_phy_mode_t,
@@ -7017,7 +7017,7 @@ pub struct wifi_tx_rate_config_t {
 #[doc = " Argument structure for regulatory rule"]
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_reg_rule_t {
     #[doc = "< start channel of regulatory rule"]
     pub start_channel: u8,
@@ -7100,7 +7100,7 @@ impl wifi_reg_rule_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regulatory_t {
     #[doc = "< number of regulatory rules"]
     pub n_reg_rules: u8,
@@ -7109,7 +7109,7 @@ pub struct wifi_regulatory_t {
 }
 #[doc = " Argument structure for regdomain"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_regdomain_t {
     #[doc = "< country code string"]
     pub cn: [crate::c_types::c_char; 2usize],
@@ -7124,7 +7124,7 @@ pub const wifi_tx_status_t_WIFI_SEND_FAIL: wifi_tx_status_t = 1;
 pub type wifi_tx_status_t = crate::c_types::c_uint;
 #[doc = " @brief Information of wifi sending data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_tx_info_t {
     #[doc = "< The address of the receive device"]
     pub des_addr: *mut u8,
@@ -7145,7 +7145,7 @@ pub struct wifi_tx_info_t {
 pub type esp_80211_tx_info_t = wifi_tx_info_t;
 #[doc = " Argument structure for WIFI_EVENT_STA_BEACON_OFFSET_UNSTABLE event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_sta_beacon_offset_unstable_t {
     #[doc = "< Received beacon success rate"]
     pub beacon_success_rate: f32,
@@ -7167,14 +7167,14 @@ pub struct wifi_event_dpp_config_received_t {
 }
 #[doc = " Argument structure for WIFI_EVENT_DPP_FAIL event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_event_dpp_failed_t {
     #[doc = "< Failure reason"]
     pub failure_reason: crate::c_types::c_int,
 }
 #[doc = " @brief List of stations associated with the Soft-AP"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_sta_list_t {
     #[doc = "< station list"]
     pub sta: [wifi_sta_info_t; 15usize],
@@ -7184,7 +7184,7 @@ pub struct wifi_sta_list_t {
 #[doc = " @brief Received packet radio metadata header, this is the common header at the beginning of all promiscuous mode RX callback buffers"]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_pkt_rx_ctrl_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 48usize]>,
@@ -7401,7 +7401,7 @@ impl wifi_pkt_rx_ctrl_t {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_config_t {
     #[doc = "< enable to receive legacy long training field(lltf) data. Default enabled"]
     pub lltf_en: bool,
@@ -7430,7 +7430,7 @@ pub struct wifi_promiscuous_pkt_t {
 }
 #[doc = " @brief CSI data type\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_csi_info_t {
     #[doc = "< received packet radio metadata header of the CSI data"]
     pub rx_ctrl: wifi_pkt_rx_ctrl_t,
@@ -7455,7 +7455,7 @@ pub struct wifi_csi_info_t {
 }
 #[doc = " Configuration for creating event loops"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_event_loop_args_t {
     #[doc = "< size of the event loop queue"]
     pub queue_size: i32,
@@ -7886,7 +7886,7 @@ pub type esp_crc32_le_t =
     ::core::option::Option<unsafe extern "C" fn(crc: u32, buf: *const u8, len: u32) -> u32>;
 #[doc = " @brief The crypto callback function structure used by esp_wifi.\n        The structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wpa_crypto_funcs_t {
     #[doc = "< The crypto callback function structure size"]
     pub size: u32,
@@ -7913,7 +7913,7 @@ pub struct wpa_crypto_funcs_t {
 }
 #[doc = " @brief The crypto callback function structure used in mesh vendor IE encryption. The\n        structure can be set as software crypto or the crypto optimized by device's\n        hardware."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct mesh_crypto_funcs_t {
     #[doc = "< Callback function used in mesh vendor IE encryption"]
     pub aes_128_encrypt: esp_aes_128_encrypt_t,
@@ -7978,7 +7978,7 @@ extern "C" {
 }
 #[doc = " @brief WiFi stack configuration parameters passed to esp_wifi_init call."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_init_config_t {
     #[doc = "< WiFi OS functions"]
     pub osi_funcs: *mut wifi_osi_funcs_t,
@@ -8491,7 +8491,7 @@ extern "C" {
 }
 #[doc = " Argument structure for SC_EVENT_GOT_SSID_PSWD event"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_event_got_ssid_pswd_t {
     #[doc = "< SSID of the AP. Null terminated string."]
     pub ssid: [u8; 32usize],
@@ -8510,7 +8510,7 @@ pub struct smartconfig_event_got_ssid_pswd_t {
 }
 #[doc = " Configure structure for esp_smartconfig_start"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct smartconfig_start_config_t {
     #[doc = "< Enable smartconfig logs."]
     pub enable_log: bool,
@@ -8556,7 +8556,7 @@ pub const wifi_ioctl_cmd_t_WIFI_IOCTL_MAX: wifi_ioctl_cmd_t = 3;
 pub type wifi_ioctl_cmd_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration for STA's HT2040 coexist management\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_ht2040_coex_t {
     #[doc = "< Indicate whether STA's HT2040 coexist management is enabled or not"]
     pub enable: crate::c_types::c_int,
@@ -8581,7 +8581,7 @@ pub const wifi_beacon_drop_t_WIFI_BEACON_DROP_FORCED: wifi_beacon_drop_t = 2;
 pub type wifi_beacon_drop_t = crate::c_types::c_uint;
 #[doc = " @brief WiFi beacon monitor parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_monitor_config_t {
     #[doc = "< Enable or disable beacon monitor"]
     pub enable: bool,
@@ -8598,7 +8598,7 @@ pub struct wifi_beacon_monitor_config_t {
 }
 #[doc = " @brief WiFi beacon sample parameter configuration\n"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_beacon_offset_config_t {
     #[doc = "< Sample beacon period, unit: number of beacons"]
     pub sample_period: u16,
@@ -8608,7 +8608,7 @@ pub struct wifi_beacon_offset_config_t {
     pub difference: u8,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_static_queue_t {
     #[doc = "< FreeRTOS queue handler"]
     pub handle: QueueHandle_t,
@@ -8616,7 +8616,7 @@ pub struct wifi_static_queue_t {
     pub storage: *mut crate::c_types::c_void,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct nan_callbacks {
     pub service_match: ::core::option::Option<
         unsafe extern "C" fn(
@@ -8986,7 +8986,7 @@ extern "C" {
     pub fn esp_wifi_enable_easy_fragment(enable: bool);
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct wifi_osi_funcs_t {
     pub _version: i32,
     pub _env_is_chip: ::core::option::Option<unsafe extern "C" fn() -> bool>,
@@ -9379,7 +9379,7 @@ extern "C" {
 }
 #[doc = " @brief Structure holding PHY init parameters"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_init_data_t {
     #[doc = "< opaque PHY initialization parameters"]
     pub params: [u8; 128usize],
@@ -9396,7 +9396,7 @@ pub const esp_phy_modem_t_PHY_MODEM_MAX: esp_phy_modem_t = 5;
 pub type esp_phy_modem_t = crate::c_types::c_uint;
 #[doc = " @brief Opaque PHY calibration data"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_phy_calibration_data_t {
     #[doc = "< PHY version"]
     pub version: [u8; 4usize],
@@ -9500,13 +9500,13 @@ extern "C" {
     pub fn esp_wifi_bt_power_domain_off();
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t {
     pub cmd_type: u8,
     pub config: phy_i2c_master_command_attribute_t__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct phy_i2c_master_command_attribute_t__bindgen_ty_1 {
     pub start: u8,
     pub end: u8,
@@ -9631,7 +9631,7 @@ pub struct esp_etm_task_t {
 pub type esp_etm_task_handle_t = *mut esp_etm_task_t;
 #[doc = " @brief ETM channel configuration"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_etm_channel_config_t {}
 extern "C" {
     #[doc = " @brief Allocate an ETM channel\n\n @note The channel can later be freed by `esp_etm_del_channel`\n\n @param[in] config ETM channel configuration\n @param[out] ret_chan Returned ETM channel handle\n @return\n      - ESP_OK: Allocate ETM channel successfully\n      - ESP_ERR_INVALID_ARG: Allocate ETM channel failed because of invalid argument\n      - ESP_ERR_NO_MEM: Allocate ETM channel failed because of out of memory\n      - ESP_ERR_NOT_FOUND: Allocate ETM channel failed because all channels are used up and no more free one\n      - ESP_FAIL: Allocate ETM channel failed because of other reasons"]
@@ -9690,7 +9690,7 @@ pub const esp_timer_dispatch_t_ESP_TIMER_MAX: esp_timer_dispatch_t = 1;
 pub type esp_timer_dispatch_t = crate::c_types::c_uint;
 #[doc = " @brief Timer configuration passed to esp_timer_create()"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_timer_create_args_t {
     #[doc = "!< Callback function to execute when timer expires"]
     pub callback: esp_timer_cb_t,
@@ -9802,7 +9802,7 @@ pub const esp_eap_method_t_ESP_EAP_TYPE_ALL: esp_eap_method_t = 15;
 pub type esp_eap_method_t = crate::c_types::c_uint;
 #[doc = " @brief Configuration settings for EAP-FAST\n        (Extensible Authentication Protocol - Flexible Authentication via Secure Tunneling).\n\n This structure defines the configuration options that can be used to customize the behavior of the\n EAP-FAST authentication protocol, specifically for Fast Provisioning and PAC (Protected Access Credential) handling."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_eap_fast_config {
     #[doc = "< Enable or disable Fast Provisioning in EAP-FAST (0 = disabled, 1 = enabled)"]
     pub fast_provisioning: crate::c_types::c_int,
@@ -9991,7 +9991,7 @@ pub type esp_bt_hci_tl_callback_t =
     ::core::option::Option<unsafe extern "C" fn(arg: *mut crate::c_types::c_void, status: u8)>;
 #[doc = " @brief Controller HCI transport layer function structure\n\n @note This structure must be registered when HCI transport layer is UART"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_hci_tl_t {
     #[doc = "< Magic number"]
     pub _magic: u32,
@@ -10030,7 +10030,7 @@ pub struct esp_bt_hci_tl_t {
 }
 #[doc = " @brief Bluetooth Controller config options\n @note\n      1. For parameters configurable through menuconfig, it is recommended to adjust them via the menuconfig interface. Please refer to menuconfig for details on the range and default values.\n      2. It is not recommended to modify the values for parameters which are not configurable through menuconfig."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_bt_controller_config_t {
     #[doc = "< Magic number"]
     pub magic: u32,
@@ -10303,7 +10303,7 @@ extern "C" {
 }
 #[doc = " @brief Virtual HCI (VHCI) callback functions to notify the Host on the next operation"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_vhci_host_callback {
     #[doc = "< callback used to notify that the Host can send the HCI data to Controller"]
     pub notify_host_send_available: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10371,7 +10371,7 @@ extern "C" {
     pub fn esp_coex_status_bit_clear(type_: esp_coex_status_type_t, status: u32) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_adapter_funcs_t {
     pub _version: i32,
     pub _task_yield_from_isr: ::core::option::Option<unsafe extern "C" fn()>,
@@ -10431,7 +10431,7 @@ extern "C" {
     pub static mut g_coex_adapter_funcs: coex_adapter_funcs_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct coex_version_t {
     pub major: u8,
     pub minor: u8,
@@ -10611,7 +10611,7 @@ pub const esp_now_send_status_t_ESP_NOW_SEND_FAIL: esp_now_send_status_t = 1;
 pub type esp_now_send_status_t = crate::c_types::c_uint;
 #[doc = " @brief ESPNOW peer information parameters."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_info {
     #[doc = "< ESPNOW peer MAC address that is also the MAC address of station or softap"]
     pub peer_addr: [u8; 6usize],
@@ -10630,7 +10630,7 @@ pub struct esp_now_peer_info {
 pub type esp_now_peer_info_t = esp_now_peer_info;
 #[doc = " @brief Number of ESPNOW peers which exist currently."]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_peer_num {
     #[doc = "< Total number of ESPNOW peers, maximum value is ESP_NOW_MAX_TOTAL_PEER_NUM"]
     pub total_num: crate::c_types::c_int,
@@ -10641,7 +10641,7 @@ pub struct esp_now_peer_num {
 pub type esp_now_peer_num_t = esp_now_peer_num;
 #[doc = " @brief ESPNOW receive packet information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_recv_info {
     #[doc = "< Source address of ESPNOW packet"]
     pub src_addr: *mut u8,
@@ -10678,7 +10678,7 @@ pub struct esp_now_switch_channel_t {
 }
 #[doc = " @brief ESPNOW remain on channel information"]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct esp_now_remain_on_channel_t {
     #[doc = "< ROC operation type"]
     pub type_: wifi_roc_t,
@@ -10799,7 +10799,7 @@ extern "C" {
     pub fn esp_now_remain_on_channel(config: *mut esp_now_remain_on_channel_t) -> esp_err_t;
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct timer_adpt {
     pub _address: u8,
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use bindgen::Builder;
+use bindgen::{
+    callbacks::{DeriveInfo, ParseCallbacks},
+    Builder,
+};
 use directories::UserDirs;
 use log::LevelFilter;
 
@@ -158,7 +161,7 @@ fn generate_bindings_for_chip(
         ])
         .ctypes_prefix("crate::c_types")
         .derive_debug(false)
-        .derive_partialeq(true)
+        .parse_callbacks(Box::new(AddPartialEq))
         .header(c_path.join("include/include.h").to_string_lossy())
         .layout_tests(false)
         .raw_line("#![allow(non_camel_case_types,non_snake_case,non_upper_case_globals,dead_code,improper_ctypes)]")
@@ -185,4 +188,26 @@ fn generate_bindings_for_chip(
         .output()?;
 
     Ok(())
+}
+
+// Types for which we want derive PartialEq added
+const PARTIALEQ_TYPES: &[&str] = &[
+    "wifi_ap_config_t",
+    "wifi_sta_config_t",
+    "wifi_scan_threshold_t",
+    "wifi_pmf_config_t",
+    "wifi_bss_max_idle_config_t",
+];
+
+#[derive(Debug)]
+struct AddPartialEq;
+
+impl ParseCallbacks for AddPartialEq {
+    fn add_derives(&self, info: &DeriveInfo<'_>) -> Vec<String> {
+        if PARTIALEQ_TYPES.contains(&info.name) {
+            vec!["PartialEq".to_string()]
+        } else {
+            vec![]
+        }
+    }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -158,6 +158,7 @@ fn generate_bindings_for_chip(
         ])
         .ctypes_prefix("crate::c_types")
         .derive_debug(false)
+        .derive_partialeq(true)
         .header(c_path.join("include/include.h").to_string_lossy())
         .layout_tests(false)
         .raw_line("#![allow(non_camel_case_types,non_snake_case,non_upper_case_globals,dead_code,improper_ctypes)]")


### PR DESCRIPTION
This makes it easy to check equality on structs. Will be used on a PR to esp-radio/wifi to fix AP disconnection issue when setting the config of a station in a station+AP setup.